### PR TITLE
Wip use new elasticsearch client

### DIFF
--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -78,7 +78,6 @@ export class FetcherTask {
   ) {
     this.internalRepository = new SavedObjectsClient(savedObjects.createInternalRepository());
     this.telemetryCollectionManager = telemetryCollectionManager;
-    // this.elasticsearchClient = elasticsearch.legacy.createClient('telemetry-fetcher');
     this.elasticsearchClient = elasticsearch.createClient('telemetry-fetcher');
 
     setTimeout(() => {
@@ -93,7 +92,6 @@ export class FetcherTask {
     }
     if (this.elasticsearchClient) {
       this.elasticsearchClient.close();
-      // this.elasticsearchClient.close();
     }
   }
 

--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -29,7 +29,8 @@ import {
   SavedObjectsClientContract,
   SavedObjectsClient,
   CoreStart,
-  ILegacyCustomClusterClient,
+  // ILegacyCustomClusterClient,
+  ICustomClusterClient,
 } from '../../../core/server';
 import {
   getTelemetryOptIn,
@@ -63,7 +64,7 @@ export class FetcherTask {
   private isSending = false;
   private internalRepository?: SavedObjectsClientContract;
   private telemetryCollectionManager?: TelemetryCollectionManagerPluginStart;
-  private elasticsearchClient?: ILegacyCustomClusterClient;
+  private elasticsearchClient?: ICustomClusterClient;
 
   constructor(initializerContext: PluginInitializerContext<TelemetryConfigType>) {
     this.config$ = initializerContext.config.create();
@@ -77,7 +78,8 @@ export class FetcherTask {
   ) {
     this.internalRepository = new SavedObjectsClient(savedObjects.createInternalRepository());
     this.telemetryCollectionManager = telemetryCollectionManager;
-    this.elasticsearchClient = elasticsearch.legacy.createClient('telemetry-fetcher');
+    // this.elasticsearchClient = elasticsearch.legacy.createClient('telemetry-fetcher');
+    this.elasticsearchClient = elasticsearch.createClient('telemetry-fetcher');
 
     setTimeout(() => {
       this.sendIfDue();
@@ -91,6 +93,7 @@ export class FetcherTask {
     }
     if (this.elasticsearchClient) {
       this.elasticsearchClient.close();
+      // this.elasticsearchClient.close();
     }
   }
 

--- a/src/plugins/telemetry/server/plugin.ts
+++ b/src/plugins/telemetry/server/plugin.ts
@@ -33,7 +33,6 @@ import {
   Plugin,
   Logger,
   IClusterClient,
-  ILegacyClusterClient,
 } from '../../../core/server';
 import { registerRoutes } from './routes';
 import { registerCollection } from './telemetry_collection';
@@ -55,10 +54,6 @@ export interface TelemetryPluginsStart {
 }
 
 type SavedObjectsRegisterType = CoreSetup['savedObjects']['registerType'];
-
-type ClusterClientGetter = () =>
-  | Pick<ILegacyClusterClient, 'callAsInternalUser' | 'asScoped'>
-  | IClusterClient;
 
 export class TelemetryPlugin implements Plugin {
   private readonly logger: Logger;
@@ -89,10 +84,8 @@ export class TelemetryPlugin implements Plugin {
     const currentKibanaVersion = this.currentKibanaVersion;
     const config$ = this.config$;
     const isDev = this.isDev;
-    const callClusterGetter = core.elasticsearch
-      ? () => core.elasticsearch.legacy.client
-      : this.getCallCluster;
-    registerCollection(telemetryCollectionManager, callClusterGetter as ClusterClientGetter);
+    const callClusterGetter = this.getCallCluster;
+    registerCollection(telemetryCollectionManager, callClusterGetter);
     const router = core.http.createRouter();
 
     registerRoutes({

--- a/src/plugins/telemetry/server/plugin.ts
+++ b/src/plugins/telemetry/server/plugin.ts
@@ -81,8 +81,7 @@ export class TelemetryPlugin implements Plugin {
     const currentKibanaVersion = this.currentKibanaVersion;
     const config$ = this.config$;
     const isDev = this.isDev;
-
-    registerCollection(telemetryCollectionManager, elasticsearch.legacy.client);
+    registerCollection(telemetryCollectionManager, elasticsearch.legacy.client); // the new es client is no longer available during setup.
     const router = http.createRouter();
 
     registerRoutes({

--- a/src/plugins/telemetry/server/plugin.ts
+++ b/src/plugins/telemetry/server/plugin.ts
@@ -90,7 +90,7 @@ export class TelemetryPlugin implements Plugin {
     const config$ = this.config$;
     const isDev = this.isDev;
     const callClusterGetter = core.elasticsearch
-      ? () => core.elasticsearch.legacy.client as ILegacyClusterClient
+      ? () => core.elasticsearch.legacy.client
       : this.getCallCluster;
     registerCollection(telemetryCollectionManager, callClusterGetter as ClusterClientGetter);
     const router = core.http.createRouter();

--- a/src/plugins/telemetry/server/telemetry_collection/register_collection.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/register_collection.ts
@@ -36,19 +36,15 @@
  * under the License.
  */
 
-import { ILegacyClusterClient, IClusterClient } from 'kibana/server';
+import { IClusterClient } from 'kibana/server';
 import { TelemetryCollectionManagerPluginSetup } from 'src/plugins/telemetry_collection_manager/server';
 import { getLocalStats } from './get_local_stats';
 import { getClusterUuids } from './get_cluster_stats';
 import { getLocalLicense } from './get_local_license';
 
-type ClusterClientGetter = () =>
-  | Pick<ILegacyClusterClient, 'callAsInternalUser' | 'asScoped'>
-  | IClusterClient;
-
 export function registerCollection(
   telemetryCollectionManager: TelemetryCollectionManagerPluginSetup,
-  callClusterGetter: ClusterClientGetter
+  callClusterGetter: () => IClusterClient
 ) {
   telemetryCollectionManager.setCollection({
     callClusterGetter,

--- a/src/plugins/telemetry/server/telemetry_collection/register_collection.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/register_collection.ts
@@ -36,7 +36,7 @@
  * under the License.
  */
 
-import { ILegacyClusterClient } from 'kibana/server';
+import { ILegacyClusterClient, IClusterClient } from 'kibana/server';
 import { TelemetryCollectionManagerPluginSetup } from 'src/plugins/telemetry_collection_manager/server';
 import { getLocalStats } from './get_local_stats';
 import { getClusterUuids } from './get_cluster_stats';
@@ -44,10 +44,10 @@ import { getLocalLicense } from './get_local_license';
 
 export function registerCollection(
   telemetryCollectionManager: TelemetryCollectionManagerPluginSetup,
-  esCluster: ILegacyClusterClient
+  getEsCluster: Promise<ILegacyClusterClient> | Promise<IClusterClient>
 ) {
   telemetryCollectionManager.setCollection({
-    esCluster,
+    getEsCluster,
     title: 'local',
     priority: 0,
     statsGetter: getLocalStats,

--- a/src/plugins/telemetry/server/telemetry_collection/register_collection.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/register_collection.ts
@@ -42,12 +42,16 @@ import { getLocalStats } from './get_local_stats';
 import { getClusterUuids } from './get_cluster_stats';
 import { getLocalLicense } from './get_local_license';
 
+type ClusterClientGetter = () =>
+  | Pick<ILegacyClusterClient, 'callAsInternalUser' | 'asScoped'>
+  | IClusterClient;
+
 export function registerCollection(
   telemetryCollectionManager: TelemetryCollectionManagerPluginSetup,
-  getEsCluster: Promise<ILegacyClusterClient> | Promise<IClusterClient>
+  callClusterGetter: ClusterClientGetter
 ) {
   telemetryCollectionManager.setCollection({
-    getEsCluster,
+    callClusterGetter,
     title: 'local',
     priority: 0,
     statsGetter: getLocalStats,

--- a/src/plugins/telemetry_collection_manager/server/plugin.ts
+++ b/src/plugins/telemetry_collection_manager/server/plugin.ts
@@ -89,12 +89,11 @@ export class TelemetryCollectionManagerPlugin
     const {
       title,
       priority,
-      esCluster,
+      callClusterGetter,
       statsGetter,
       clusterDetailsGetter,
       licenseGetter,
     } = collectionConfig;
-
     if (typeof priority !== 'number') {
       throw new Error('priority must be set.');
     }
@@ -106,8 +105,8 @@ export class TelemetryCollectionManagerPlugin
       if (!statsGetter) {
         throw Error('Stats getter method not set.');
       }
-      if (!esCluster) {
-        throw Error('esCluster name must be set for the getCluster method.');
+      if (!callClusterGetter) {
+        throw Error('callClusterGetter needs to be a method');
       }
       if (!clusterDetailsGetter) {
         throw Error('Cluster UUIds method is not set.');
@@ -120,7 +119,7 @@ export class TelemetryCollectionManagerPlugin
         licenseGetter,
         statsGetter,
         clusterDetailsGetter,
-        esCluster,
+        callClusterGetter,
         title,
       });
       this.usageGetterMethodPriority = priority;

--- a/src/plugins/telemetry_collection_manager/server/types.ts
+++ b/src/plugins/telemetry_collection_manager/server/types.ts
@@ -144,6 +144,6 @@ export interface Collection<
   statsGetter: StatsGetter<CustomContext, T>;
   licenseGetter: LicenseGetter<CustomContext>;
   clusterDetailsGetter: ClusterDetailsGetter<CustomContext>;
-  esCluster: ILegacyClusterClient;
+  esCluster: ILegacyClusterClient; // this needs to change to the new es client that's not available on the setup method.
   title: string;
 }

--- a/src/plugins/telemetry_collection_manager/server/types.ts
+++ b/src/plugins/telemetry_collection_manager/server/types.ts
@@ -150,7 +150,7 @@ export interface Collection<
   statsGetter: StatsGetter<CustomContext, T>;
   licenseGetter: LicenseGetter<CustomContext>;
   clusterDetailsGetter: ClusterDetailsGetter<CustomContext>;
-  esCluster: ILegacyClusterClient | IClusterClient; // this needs to change to the new es client that's not available on the setup method.
+  callClusterGetter: ClusterClientGetter; // this needs to change to the new es client that's not available on the setup method.
   title: string;
 }
 

--- a/src/plugins/telemetry_collection_manager/server/types.ts
+++ b/src/plugins/telemetry_collection_manager/server/types.ts
@@ -135,7 +135,7 @@ export interface CollectionConfig<
 > {
   title: string;
   priority: number;
-  getEsCluster: Promise<ILegacyClusterClient> | Promise<IClusterClient>;
+  callClusterGetter: ClusterClientGetter;
   statsGetter: StatsGetter<CustomContext, T>;
   clusterDetailsGetter: ClusterDetailsGetter<CustomContext>;
   licenseGetter: LicenseGetter<CustomContext>;
@@ -153,3 +153,7 @@ export interface Collection<
   esCluster: ILegacyClusterClient | IClusterClient; // this needs to change to the new es client that's not available on the setup method.
   title: string;
 }
+
+type ClusterClientGetter = () =>
+  | Pick<ILegacyClusterClient, 'callAsInternalUser' | 'asScoped'>
+  | IClusterClient;

--- a/src/plugins/telemetry_collection_manager/server/types.ts
+++ b/src/plugins/telemetry_collection_manager/server/types.ts
@@ -17,7 +17,13 @@
  * under the License.
  */
 
-import { LegacyAPICaller, Logger, KibanaRequest, ILegacyClusterClient } from 'kibana/server';
+import {
+  LegacyAPICaller,
+  Logger,
+  KibanaRequest,
+  ILegacyClusterClient,
+  IClusterClient,
+} from 'kibana/server';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 import { TelemetryCollectionManagerPlugin } from './plugin';
 
@@ -64,7 +70,7 @@ export interface ClusterDetails {
 
 export interface StatsCollectionConfig {
   usageCollection: UsageCollectionSetup;
-  callCluster: LegacyAPICaller;
+  callCluster: LegacyAPICaller | IClusterClient;
   start: string | number;
   end: string | number;
 }
@@ -129,7 +135,7 @@ export interface CollectionConfig<
 > {
   title: string;
   priority: number;
-  esCluster: ILegacyClusterClient;
+  getEsCluster: Promise<ILegacyClusterClient> | Promise<IClusterClient>;
   statsGetter: StatsGetter<CustomContext, T>;
   clusterDetailsGetter: ClusterDetailsGetter<CustomContext>;
   licenseGetter: LicenseGetter<CustomContext>;
@@ -144,6 +150,6 @@ export interface Collection<
   statsGetter: StatsGetter<CustomContext, T>;
   licenseGetter: LicenseGetter<CustomContext>;
   clusterDetailsGetter: ClusterDetailsGetter<CustomContext>;
-  esCluster: ILegacyClusterClient; // this needs to change to the new es client that's not available on the setup method.
+  esCluster: ILegacyClusterClient | IClusterClient; // this needs to change to the new es client that's not available on the setup method.
   title: string;
 }

--- a/src/plugins/telemetry_collection_manager/server/types.ts
+++ b/src/plugins/telemetry_collection_manager/server/types.ts
@@ -17,13 +17,7 @@
  * under the License.
  */
 
-import {
-  LegacyAPICaller,
-  Logger,
-  KibanaRequest,
-  ILegacyClusterClient,
-  IClusterClient,
-} from 'kibana/server';
+import { Logger, KibanaRequest, IClusterClient, ElasticsearchClient } from 'kibana/server';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 import { TelemetryCollectionManagerPlugin } from './plugin';
 
@@ -70,7 +64,7 @@ export interface ClusterDetails {
 
 export interface StatsCollectionConfig {
   usageCollection: UsageCollectionSetup;
-  callCluster: LegacyAPICaller | IClusterClient;
+  callCluster: ElasticsearchClient;
   start: string | number;
   end: string | number;
 }
@@ -135,7 +129,7 @@ export interface CollectionConfig<
 > {
   title: string;
   priority: number;
-  callClusterGetter: ClusterClientGetter;
+  callClusterGetter: () => IClusterClient;
   statsGetter: StatsGetter<CustomContext, T>;
   clusterDetailsGetter: ClusterDetailsGetter<CustomContext>;
   licenseGetter: LicenseGetter<CustomContext>;
@@ -150,10 +144,6 @@ export interface Collection<
   statsGetter: StatsGetter<CustomContext, T>;
   licenseGetter: LicenseGetter<CustomContext>;
   clusterDetailsGetter: ClusterDetailsGetter<CustomContext>;
-  callClusterGetter: ClusterClientGetter; // this needs to change to the new es client that's not available on the setup method.
+  callClusterGetter: () => IClusterClient; // this needs to change to the new es client that's not available on the setup method.
   title: string;
 }
-
-type ClusterClientGetter = () =>
-  | Pick<ILegacyClusterClient, 'callAsInternalUser' | 'asScoped'>
-  | IClusterClient;

--- a/src/plugins/usage_collection/server/collector/collector.ts
+++ b/src/plugins/usage_collection/server/collector/collector.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Logger, LegacyAPICaller } from 'kibana/server';
+import { Logger, LegacyAPICaller, IClusterClient } from 'kibana/server';
 
 export type CollectorFormatForBulkUpload<T, U> = (result: T) => { type: string; payload: U };
 
@@ -48,7 +48,9 @@ export interface CollectorOptions<T = unknown, U = T> {
   type: string;
   init?: Function;
   schema?: MakeSchemaFrom<Required<T>>; // Using Required to enforce all optional keys in the object
-  fetch: (callCluster: LegacyAPICaller) => Promise<T> | T;
+  fetch: (
+    getCallCluster: () => Promise<LegacyAPICaller> | Promise<IClusterClient>
+  ) => Promise<T> | T;
   /*
    * A hook for allowing the fetched data payload to be organized into a typed
    * data model for internal bulk upload. See defaultFormatterForBulkUpload for

--- a/src/plugins/usage_collection/server/collector/collector.ts
+++ b/src/plugins/usage_collection/server/collector/collector.ts
@@ -48,9 +48,7 @@ export interface CollectorOptions<T = unknown, U = T> {
   type: string;
   init?: Function;
   schema?: MakeSchemaFrom<Required<T>>; // Using Required to enforce all optional keys in the object
-  fetch: (
-    getCallCluster: () => Promise<LegacyAPICaller> | Promise<IClusterClient>
-  ) => Promise<T> | T;
+  fetch: (callCluster: IClusterClient) => Promise<T> | T;
   /*
    * A hook for allowing the fetched data payload to be organized into a typed
    * data model for internal bulk upload. See defaultFormatterForBulkUpload for

--- a/src/plugins/usage_collection/server/collector/collector_set.ts
+++ b/src/plugins/usage_collection/server/collector/collector_set.ts
@@ -76,7 +76,9 @@ export class CollectorSet {
   };
 
   public areAllCollectorsReady = async (collectorSet: CollectorSet = this) => {
-    // potentially return false if any collector's fetch method returns undefined for getCallCluster
+    // Tina TODO: potentially return false if any collector returns undefined for getCallCluster
+    // I need to ADD getCallCluster to the Collector class.
+
     // Kept this for runtime validation in JS code.
     if (!(collectorSet instanceof CollectorSet)) {
       throw new Error(
@@ -94,6 +96,15 @@ export class CollectorSet {
       )
     ).filter((collectorType): collectorType is string => !!collectorType);
     const allReady = collectorTypesNotReady.length === 0;
+
+    const collectorClusterClientsNotReady = await Promise.all(
+      [...collectorSet.collectors.values()].map((collector) => {
+        // how to I call getClusterGetter within the fetch method?
+        if (!collector.getCluster) {
+          return collector.type;
+        }
+      })
+    );
 
     if (!allReady && this.maximumWaitTimeForAllCollectorsInS >= 0) {
       const nowTimestamp = +new Date();
@@ -122,9 +133,9 @@ export class CollectorSet {
     callCluster: LegacyAPICaller, // we will receive the getter.
     collectors: Map<string, Collector<any, any>> = this.collectors
   ) => {
-    // first check that we get something from the callCluster getter.
-    // if we don't get anything return an empty array.
-    // get the cluster and pass into the fetch method.
+    // Tina TODO: Then also first check that we get something from the callCluster getter.
+    // 2. if we don't get anything return an empty array.
+    // 3. then get the cluster and pass that into the fetch method.
     const responses = await Promise.all(
       [...collectors.values()].map(async (collector) => {
         this.logger.debug(`Fetching data from ${collector.type} collector`);

--- a/src/plugins/usage_collection/server/collector/collector_set.ts
+++ b/src/plugins/usage_collection/server/collector/collector_set.ts
@@ -119,16 +119,20 @@ export class CollectorSet {
   };
 
   public bulkFetch = async (
-    callCluster: LegacyAPICaller,
+    callCluster: LegacyAPICaller, // we will receive the getter.
     collectors: Map<string, Collector<any, any>> = this.collectors
   ) => {
+    // first check that we get something from the callCluster getter.
+    // if we don't get anything return an empty array.
+    // get the cluster and pass into the fetch method.
     const responses = await Promise.all(
       [...collectors.values()].map(async (collector) => {
         this.logger.debug(`Fetching data from ${collector.type} collector`);
         try {
           return {
             type: collector.type,
-            result: await collector.fetch(callCluster),
+            result: await collector.fetch(callCluster), // -> provide all the other context in here too. { all the additional API's we want to expose: scoped Saved Object, request from Kibana and the rest.}
+            // result: await collector.fetch({.....everything})
           };
         } catch (err) {
           this.logger.warn(err);

--- a/src/plugins/usage_collection/server/collector/collector_set.ts
+++ b/src/plugins/usage_collection/server/collector/collector_set.ts
@@ -76,6 +76,7 @@ export class CollectorSet {
   };
 
   public areAllCollectorsReady = async (collectorSet: CollectorSet = this) => {
+    // potentially return false if any collector's fetch method returns undefined for getCallCluster
     // Kept this for runtime validation in JS code.
     if (!(collectorSet instanceof CollectorSet)) {
       throw new Error(


### PR DESCRIPTION
### WIP
This PR stashes the original implementation of updating the ES client by completely replacing `callCluster`.

Revised thinking suggests adding the new client is a less risky approach.