### PR TITLE
WIP [so-migrations]Don't fail on first SO transform failure

### DIFF
--- a/src/core/server/saved_objects/migrations/core/migrate_raw_docs.test.ts
+++ b/src/core/server/saved_objects/migrations/core/migrate_raw_docs.test.ts
@@ -57,7 +57,7 @@ describe('migrateRawDocs', () => {
     expect(transform).toHaveBeenNthCalledWith(1, obj1);
     expect(transform).toHaveBeenNthCalledWith(2, obj2);
   });
-
+  // we don't want to throw
   test('throws when encountering a corrupt saved object document', async () => {
     const logger = createSavedObjectsMigrationLoggerMock();
     const transform = jest.fn<any, any>((doc: any) => [

--- a/src/core/server/saved_objects/migrations/core/migrate_raw_docs.ts
+++ b/src/core/server/saved_objects/migrations/core/migrate_raw_docs.ts
@@ -9,7 +9,8 @@
 /*
  * This file provides logic for migrating raw documents.
  */
-import { TaskEither } from 'fp-ts/lib/TaskEither';
+import * as TaskEither from 'fp-ts/lib/TaskEither';
+import * as Either from 'fp-ts/lib/Either';
 import {
   SavedObjectsRawDoc,
   SavedObjectsSerializer,
@@ -78,24 +79,24 @@ export async function migrateRawDocs(
  */
 export interface DocumentsTransformFailed {
   type: string;
-  corruptSavedObjectIds: string[];
+  failedDocumentIds: string[];
 }
 export interface DocumentsTransformSuccess {
   processedDocs: SavedObjectsRawDoc[];
 }
 
-export async function migrateRawDocsNonThrowing(
+export function migrateRawDocsNonThrowing(
   serializer: SavedObjectsSerializer,
   migrateDoc: MigrateAndConvertFn,
   rawDocs: SavedObjectsRawDoc[],
   log: SavedObjectsMigrationLogger
   // This method should never fail because we're returning an array of something, either transformed raw saved objects or an array of saved object ids.
   // According to the docs we should be using a Task for process that will never fail
-): TaskEither<DocumentsTransformFailed, DocumentsTransformSuccess> {
-  const migrateDocWithoutBlocking = transformNonBlocking(migrateDoc);
-  const processedDocs: SavedObjectsRawDoc[] = [];
-  const corruptSavedObjectIds: string[] = [];
-  try {
+): TaskEither.TaskEither<DocumentsTransformFailed, DocumentsTransformSuccess> {
+  return async () => {
+    const migrateDocWithoutBlocking = transformNonBlocking(migrateDoc);
+    const processedDocs: SavedObjectsRawDoc[] = [];
+    const corruptSavedObjectIds: string[] = [];
     for (const raw of rawDocs) {
       const options = { namespaceTreatment: 'lax' as const };
       if (serializer.isRawSavedObject(raw, options)) {
@@ -117,12 +118,13 @@ export async function migrateRawDocsNonThrowing(
     if (corruptSavedObjectIds.length > 0) {
       // Do we need to return an error in order to transform the method into a TaskEither? i.e. should we return an error for a bulk failure. e.g.
       // return Either.left({ type: 'document_transform_failed', new DocumentTransformFailuresError(corruptSavedObjectIds.toString())})
-      return { type: 'document_transform_failed', corruptSavedObjectIds };
+      return Either.left({
+        type: 'documents_transform_failed',
+        failedDocumentIds: [...corruptSavedObjectIds],
+      });
     }
-    return { processedDocs };
-  } catch (e) {
-    throw e;
-  }
+    return Either.right({ processedDocs });
+  };
 }
 /**
  * Migration transform functions are potentially CPU heavy e.g. doing decryption/encryption

--- a/src/core/server/saved_objects/migrations/kibana/kibana_migrator.ts
+++ b/src/core/server/saved_objects/migrations/kibana/kibana_migrator.ts
@@ -201,12 +201,6 @@ export class KibanaMigrator {
               migrationVersionPerType: this.documentMigrator.migrationVersion,
               indexPrefix: index,
               migrationsConfig: this.soMigrationsConfig,
-              captureTransformRawDocsErrors: (collection: Error[], specificErrors: Error[]) =>
-                logCorruptSavedObjectsErrors(
-                  collection,
-                  specificErrors,
-                  new MigrationLogger(this.log)
-                ),
             });
           },
         };
@@ -281,6 +275,7 @@ export type LogCorruptSavedObjectsErrors = (
 ) => string;
 // TINA there's a better way to handle this and I don't think we even need
 // to but I'm trying to not have to throw in OUTDATED_DOCUMENTS_TRANSFORM
+// don't need to do this, we just throw from next. These will be different errors though thrown from the transform raw docs function
 export function logCorruptSavedObjectsErrors(
   existing: Error[],
   newCollection: Error[],

--- a/src/core/server/saved_objects/migrationsv2/actions/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/index.ts
@@ -21,6 +21,7 @@ import {
   catchRetryableEsClientErrors,
   RetryableEsClientError,
 } from './catch_retryable_es_client_errors';
+import { DocumentsTransformFailed } from '../../migrations/core/migrate_raw_docs';
 export type { RetryableEsClientError };
 
 /**
@@ -45,6 +46,7 @@ export interface ActionErrorTypeMap {
   incompatible_mapping_exception: IncompatibleMappingException;
   alias_not_found_exception: AliasNotFound;
   remove_index_not_a_concrete_index: RemoveIndexNotAConcreteIndex;
+  documents_transform_failed: DocumentsTransformFailed;
 }
 
 /**

--- a/src/core/server/saved_objects/migrationsv2/actions/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/index.ts
@@ -595,6 +595,17 @@ export const waitForPickupUpdatedMappingsTask = flow(
   )
 );
 
+/**
+ * TINA: Dealing with not failing on first doc transform issue
+ */
+
+const transformRawDocsNonThrowing = (): TaskEither.TaskEither<
+  { type: 'document_transform_failed'; corruptSavedObjectIds: string[] },
+  SavedObjectsRawDoc[]
+> => () => {
+  // we would have returned the indexing step in here
+  return 'hello' as const;
+};
 export interface AliasNotFound {
   type: 'alias_not_found_exception';
 }

--- a/src/core/server/saved_objects/migrationsv2/actions/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/index.ts
@@ -594,18 +594,6 @@ export const waitForPickupUpdatedMappingsTask = flow(
     }
   )
 );
-
-/**
- * TINA: Dealing with not failing on first doc transform issue
- */
-
-const transformRawDocsNonThrowing = (): TaskEither.TaskEither<
-  { type: 'document_transform_failed'; corruptSavedObjectIds: string[] },
-  SavedObjectsRawDoc[]
-> => () => {
-  // we would have returned the indexing step in here
-  return 'hello' as const;
-};
 export interface AliasNotFound {
   type: 'alias_not_found_exception';
 }

--- a/src/core/server/saved_objects/migrationsv2/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/index.ts
@@ -41,7 +41,6 @@ export async function runResilientMigrator({
   migrationVersionPerType: SavedObjectsMigrationVersion;
   indexPrefix: string;
   migrationsConfig: SavedObjectsMigrationConfigType;
-  // TINA: added to log errors and not throw in OUTDATED_DOCUMENTS_TRANSFORM
 }): Promise<MigrationResult> {
   const initialState = createInitialState({
     kibanaVersion,

--- a/src/core/server/saved_objects/migrationsv2/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/index.ts
@@ -57,7 +57,7 @@ export async function runResilientMigrator({
   return migrationStateActionMachine({
     initialState,
     logger,
-    next: next(client, transformRawDocs),
+    next: next(client, transformRawDocs, captureTransformRawDocsErrors),
     model,
   });
 }

--- a/src/core/server/saved_objects/migrationsv2/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/index.ts
@@ -15,7 +15,6 @@ import { next, TransformRawDocs } from './next';
 import { createInitialState, model } from './model';
 import { migrationStateActionMachine } from './migrations_state_action_machine';
 import { SavedObjectsMigrationConfigType } from '../saved_objects_config';
-import { LogCorruptSavedObjectsErrors } from '../migrations/kibana/kibana_migrator';
 
 /**
  * Migrates the provided indexPrefix index using a resilient algorithm that is
@@ -32,7 +31,6 @@ export async function runResilientMigrator({
   migrationVersionPerType,
   indexPrefix,
   migrationsConfig,
-  captureTransformRawDocsErrors,
 }: {
   client: ElasticsearchClient;
   kibanaVersion: string;
@@ -44,7 +42,6 @@ export async function runResilientMigrator({
   indexPrefix: string;
   migrationsConfig: SavedObjectsMigrationConfigType;
   // TINA: added to log errors and not throw in OUTDATED_DOCUMENTS_TRANSFORM
-  captureTransformRawDocsErrors: LogCorruptSavedObjectsErrors;
 }): Promise<MigrationResult> {
   const initialState = createInitialState({
     kibanaVersion,
@@ -57,7 +54,7 @@ export async function runResilientMigrator({
   return migrationStateActionMachine({
     initialState,
     logger,
-    next: next(client, transformRawDocs, captureTransformRawDocsErrors),
+    next: next(client, transformRawDocs),
     model,
   });
 }

--- a/src/core/server/saved_objects/migrationsv2/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/index.ts
@@ -15,6 +15,7 @@ import { next, TransformRawDocs } from './next';
 import { createInitialState, model } from './model';
 import { migrationStateActionMachine } from './migrations_state_action_machine';
 import { SavedObjectsMigrationConfigType } from '../saved_objects_config';
+import { LogCorruptSavedObjectsErrors } from '../migrations/kibana/kibana_migrator';
 
 /**
  * Migrates the provided indexPrefix index using a resilient algorithm that is
@@ -31,6 +32,7 @@ export async function runResilientMigrator({
   migrationVersionPerType,
   indexPrefix,
   migrationsConfig,
+  captureTransformRawDocsErrors,
 }: {
   client: ElasticsearchClient;
   kibanaVersion: string;
@@ -41,6 +43,8 @@ export async function runResilientMigrator({
   migrationVersionPerType: SavedObjectsMigrationVersion;
   indexPrefix: string;
   migrationsConfig: SavedObjectsMigrationConfigType;
+  // TINA: added to log errors and not throw in OUTDATED_DOCUMENTS_TRANSFORM
+  captureTransformRawDocsErrors: LogCorruptSavedObjectsErrors;
 }): Promise<MigrationResult> {
   const initialState = createInitialState({
     kibanaVersion,

--- a/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
+++ b/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
@@ -51,7 +51,7 @@ const logActionResponse = (
 ) => {
   logger.debug(logMessagePrefix + `${state.controlState} RESPONSE`, res as LogMeta);
 };
-
+// naming here is misleading, dumpExecutionLog "dumps" the log messages, it doesn't delete them.
 const dumpExecutionLog = (logger: Logger, logMessagePrefix: string, executionLog: ExecutionLog) => {
   logger.error(logMessagePrefix + 'migration failed, dumping execution log:');
   executionLog.forEach((log) => {
@@ -140,7 +140,6 @@ export async function migrationStateActionMachine({
       }
     } else if (finalState.controlState === 'FATAL') {
       dumpExecutionLog(logger, logMessagePrefix, executionLog);
-      // store this error and return the collection on final failure
       return Promise.reject(
         new Error(
           `Unable to complete saved object migrations for the [${initialState.indexPrefix}] index: ` +
@@ -152,12 +151,10 @@ export async function migrationStateActionMachine({
     }
   } catch (e) {
     if (e instanceof EsErrors.ResponseError) {
-      // store this error and return the collection on final failure
       logger.error(
         logMessagePrefix + `[${e.body?.error?.type}]: ${e.body?.error?.reason ?? e.message}`
       );
       dumpExecutionLog(logger, logMessagePrefix, executionLog);
-      // store this error and return the collection on final failure
       throw new Error(
         `Unable to complete saved object migrations for the [${
           initialState.indexPrefix
@@ -170,7 +167,6 @@ export async function migrationStateActionMachine({
 
       dumpExecutionLog(logger, logMessagePrefix, executionLog);
       if (e instanceof CorruptSavedObjectError) {
-        // store this error and return the collection on final failure
         throw new Error(
           `${e.message} To allow migrations to proceed, please delete this document from the [${initialState.indexPrefix}_${initialState.kibanaVersion}_001] index.`
         );

--- a/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
+++ b/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
@@ -51,7 +51,6 @@ const logActionResponse = (
 ) => {
   logger.debug(logMessagePrefix + `${state.controlState} RESPONSE`, res as LogMeta);
 };
-// naming here is misleading, dumpExecutionLog "dumps" the log messages, it doesn't delete them.
 const dumpExecutionLog = (logger: Logger, logMessagePrefix: string, executionLog: ExecutionLog) => {
   logger.error(logMessagePrefix + 'migration failed, dumping execution log:');
   executionLog.forEach((log) => {
@@ -166,11 +165,6 @@ export async function migrationStateActionMachine({
       logger.error(e);
 
       dumpExecutionLog(logger, logMessagePrefix, executionLog);
-      if (e instanceof CorruptSavedObjectError) {
-        throw new Error(
-          `${e.message} To allow migrations to proceed, please delete this document from the [${initialState.indexPrefix}_${initialState.kibanaVersion}_001] index.`
-        );
-      }
 
       throw new Error(
         `Unable to complete saved object migrations for the [${initialState.indexPrefix}] index. ${e}`

--- a/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
+++ b/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
@@ -140,6 +140,7 @@ export async function migrationStateActionMachine({
       }
     } else if (finalState.controlState === 'FATAL') {
       dumpExecutionLog(logger, logMessagePrefix, executionLog);
+      // store this error and return the collection on final failure
       return Promise.reject(
         new Error(
           `Unable to complete saved object migrations for the [${initialState.indexPrefix}] index: ` +
@@ -151,10 +152,12 @@ export async function migrationStateActionMachine({
     }
   } catch (e) {
     if (e instanceof EsErrors.ResponseError) {
+      // store this error and return the collection on final failure
       logger.error(
         logMessagePrefix + `[${e.body?.error?.type}]: ${e.body?.error?.reason ?? e.message}`
       );
       dumpExecutionLog(logger, logMessagePrefix, executionLog);
+      // store this error and return the collection on final failure
       throw new Error(
         `Unable to complete saved object migrations for the [${
           initialState.indexPrefix
@@ -167,6 +170,7 @@ export async function migrationStateActionMachine({
 
       dumpExecutionLog(logger, logMessagePrefix, executionLog);
       if (e instanceof CorruptSavedObjectError) {
+        // store this error and return the collection on final failure
         throw new Error(
           `${e.message} To allow migrations to proceed, please delete this document from the [${initialState.indexPrefix}_${initialState.kibanaVersion}_001] index.`
         );

--- a/src/core/server/saved_objects/migrationsv2/model.ts
+++ b/src/core/server/saved_objects/migrationsv2/model.ts
@@ -200,6 +200,7 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
             indices[aliases[stateP.currentAlias]].mappings
           ),
           versionIndexReadyActions: Option.none,
+          failedDocumentIds: [],
         };
       } else if (
         // `.kibana` is pointing to an index that belongs to a later
@@ -548,6 +549,7 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
       return {
         ...stateP,
         controlState: 'OUTDATED_DOCUMENTS_SEARCH',
+        failedDocumentIds: [],
       };
     } else {
       const left = res.left;
@@ -560,6 +562,7 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
         return {
           ...stateP,
           controlState: 'OUTDATED_DOCUMENTS_SEARCH',
+          failedDocumentIds: [],
         };
       } else {
         throwBadResponse(stateP, left);
@@ -577,45 +580,59 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
           outdatedDocuments: res.right.outdatedDocuments,
         };
       } else {
-        // If there are no more results we have transformed all outdated
-        // documents and can proceed to the next step
-        return {
-          ...stateP,
-          controlState: 'UPDATE_TARGET_MAPPINGS',
-        };
+        if (stateP.failedDocumentIds.length > 0) {
+          // We have documents that couldn't be transformed and exit out of the migration
+          return {
+            ...stateP,
+            controlState: 'FATAL',
+            reason: `Migrations failed because of the following corrupt saved object documents: ${JSON.stringify(
+              stateP.failedDocumentIds
+            )}. To allow migrations to proceed, please delete thse documents.`,
+          };
+        } else {
+          // If there are no more results we have transformed all outdated
+          // documents and can proceed to the next step
+          return {
+            ...stateP,
+            controlState: 'UPDATE_TARGET_MAPPINGS',
+          };
+        }
       }
     } else {
       throwBadResponse(stateP, res);
     }
   } else if (stateP.controlState === 'OUTDATED_DOCUMENTS_TRANSFORM') {
-    // if any docs can't be migrated we don't try to index any ones that can and continue with the search to build up a complete list of all the error docs
-    // res should have processedDocs and the corruptSavedObjectIds (actual error with the doc Ids embedded in the error message string.
-    // there may be more than document Id in the error string and we'll need to split the string to do a count)
-    const res = resW as ExcludeRetryableEsError<ResponseType<typeof stateP.controlState>>; // we actually need both the success and failed results here.
+    const res = resW as ExcludeRetryableEsError<ResponseType<typeof stateP.controlState>>;
     if (Either.isRight(res)) {
-      // if we don't have any corrupt documents on state then index the transformed docs
-      // state needs a new property for corruptSavedObjects
-      if (stateP.corruptSavedObjectIds.length === 0) {
-        return {
-          ...stateP,
-          controlState: 'TRANSFORMED_DOCUMENTS_BULK_INDEX',
-        };
-      } else {
-        // we do have a collection of corruptSavedObjectDocs and need to reissue the OUTDATED_DOCUMENTS_SEARCH
-        // carry on searching through the rest of the batches
+      if (res.right.processedDocs.length > 0) {
+        if (stateP.failedDocumentIds.length === 0) {
+          return {
+            ...stateP,
+            controlState: 'TRANSFORMED_DOCUMENTS_BULK_INDEX',
+          };
+        } else {
+          return {
+            ...stateP,
+            controlState: 'OUTDATED_DOCUMENTS_SEARCH',
+          };
+        }
+      }
+    } else if (Either.isLeft(res) && isLeftTypeof(res.left, 'documents_transform_failed')) {
+      if (stateP.failedDocumentIds.length === 0) {
         return {
           ...stateP,
           controlState: 'OUTDATED_DOCUMENTS_SEARCH',
+          failedDocumentIds: [...res.left.failedDocumentIds],
+        };
+      } else {
+        return {
+          ...stateP,
+          controlState: 'OUTDATED_DOCUMENTS_SEARCH',
+          failedDocumentIds: [...stateP.failedDocumentIds, ...res.left.failedDocumentIds],
         };
       }
     } else {
-      // handles the case when we return a Either.Left situation that is when the return from migrateRawDocsNonThrowing is an instance of Either.Left containing the function that returns the promise of corruptSavedObjects (they're errors right now but we might want to change that to a list of raw._id)
-      return {
-        ...stateP,
-        controlState: 'OUTDATED_DOCUMENTS_SEARCH',
-        corruptSavedObjectIds: [...stateP.corruptSavedObjectIds, res.corruptSavedObjectIds],
-      };
-      // throwBadResponse(stateP, res);
+      throwBadResponse(stateP, res as never);
     }
   } else if (stateP.controlState === 'UPDATE_TARGET_MAPPINGS') {
     const res = resW as ExcludeRetryableEsError<ResponseType<typeof stateP.controlState>>;
@@ -624,6 +641,17 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
         ...stateP,
         controlState: 'UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK',
         updateTargetMappingsTaskId: res.right.taskId,
+      };
+    } else {
+      throwBadResponse(stateP, res);
+    }
+  } else if (stateP.controlState === 'TRANSFORMED_DOCUMENTS_BULK_INDEX') {
+    const res = resW as ExcludeRetryableEsError<ResponseType<typeof stateP.controlState>>;
+    if (Either.isRight(res)) {
+      return {
+        ...stateP,
+        controlState: 'OUTDATED_DOCUMENTS_SEARCH',
+        failedDocumentIds: [],
       };
     } else {
       throwBadResponse(stateP, res);

--- a/src/core/server/saved_objects/migrationsv2/model.ts
+++ b/src/core/server/saved_objects/migrationsv2/model.ts
@@ -589,8 +589,9 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
     }
   } else if (stateP.controlState === 'OUTDATED_DOCUMENTS_TRANSFORM') {
     // if any docs can't be migrated we don't try to index any ones that can and continue with the search to build up a complete list of all the error docs
-    // res should now have processedDocs and the corruptSavedObjectErrors (actual errors with the doc Id embedded in the error message string it)
-    const res = resW as ExcludeRetryableEsError<ResponseType<typeof stateP.controlState>>;
+    // res should have processedDocs and the corruptSavedObjectIds (actual error with the doc Ids embedded in the error message string.
+    // there may be more than document Id in the error string and we'll need to split the string to do a count)
+    const res = resW as ExcludeRetryableEsError<ResponseType<typeof stateP.controlState>>; // we actually need both the success and failed results here.
     if (Either.isRight(res)) {
       // if we don't have any corrupt documents on state then index the transformed docs
       // state needs a new property for corruptSavedObjects

--- a/src/core/server/saved_objects/migrationsv2/next.ts
+++ b/src/core/server/saved_objects/migrationsv2/next.ts
@@ -43,8 +43,8 @@ import {
 // How do i handle this type now that transformRawDocs is actually running migrateRawDocsNonThrowing
 // migrateRawDocsNonThrowing returns an Either.left with failed docs or an Either.right with successfylly processed/transformed docs
 export type TransformRawDocs = (
-  processedDocs: SavedObjectsRawDoc[] | { corruptSavedObjectIds: string[]; type: string }
-) => Promise<DocumentsTransformSuccess | DocumentsTransformFailed>;
+  processedDocs: SavedObjectsRawDoc[]
+) => TaskEither.TaskEither<DocumentsTransformFailed, DocumentsTransformSuccess>;
 
 type ActionMap = ReturnType<typeof nextActionMap>;
 
@@ -87,22 +87,9 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
         outdatedDocumentsQuery: state.outdatedDocumentsQuery,
       }),
     OUTDATED_DOCUMENTS_TRANSFORM: (state: OutdatedDocumentsTransform) =>
-      // this needs to change because we're no longer throwing anything from the transformRawDocs method
-      TaskEither.tryCatch(
-        () => transformRawDocs(state.outdatedDocuments), // one of { processedDocs } or { type: 'document_transform_failed', corruptSavedObjectIds }
-        (e) => {
-          // TINA: we throw for realy bad errors
-          throw e;
-        }
-      ),
+      transformRawDocs(state.outdatedDocuments), // one of { processedDocs } or { type: 'document_transform_failed', corruptSavedObjectIds }
     TRANSFORMED_DOCUMENTS_BULK_INDEX: (state: any) =>
-      // The call to this action was being handled in OUTDATES_DOCUMENTS_TRANSFORM:
-      //         TaskEither.chain((docs) =>
-      //     Actions.bulkOverwriteTransformedDocuments(client, state.targetIndex, docs)
-      //   )
-      // ),
-      // How to I get access to the processedDocs now?
-      Actions.bulkOverwriteTransformedDocuments(client, state.targetIndex, docs.processedDocs),
+      Actions.bulkOverwriteTransformedDocuments(client, state.targetIndex, state.processedDocs),
     MARK_VERSION_INDEX_READY: (state: MarkVersionIndexReady) =>
       Actions.updateAliases(client, state.versionIndexReadyActions.value),
     MARK_VERSION_INDEX_READY_CONFLICT: (state: MarkVersionIndexReadyConflict) =>

--- a/src/core/server/saved_objects/migrationsv2/next.ts
+++ b/src/core/server/saved_objects/migrationsv2/next.ts
@@ -36,6 +36,11 @@ import {
 import * as Actions from './actions';
 import { ElasticsearchClient } from '../../elasticsearch';
 import { SavedObjectsRawDoc } from '..';
+import {
+  LogCaptureTransformRawDocsErrors,
+  LogCorruptSavedObjectsErrors,
+} from '../migrations/kibana/kibana_migrator';
+import { MigrationLogger } from '../migrations/core/migration_logger';
 
 export type TransformRawDocs = (rawDocs: SavedObjectsRawDoc[]) => Promise<SavedObjectsRawDoc[]>;
 type ActionMap = ReturnType<typeof nextActionMap>;
@@ -50,7 +55,11 @@ export type ResponseType<ControlState extends AllActionStates> = UnwrapPromise<
   ReturnType<ReturnType<ActionMap[ControlState]>>
 >;
 
-export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: TransformRawDocs) => {
+export const nextActionMap = (
+  client: ElasticsearchClient,
+  transformRawDocs: TransformRawDocs,
+  captureTransformRawDocsErrors: LogCaptureTransformRawDocsErrors
+) => {
   return {
     INIT: (state: InitState) =>
       Actions.fetchIndices(client, [state.currentAlias, state.versionAlias]),
@@ -83,9 +92,12 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
         TaskEither.tryCatch(
           () => transformRawDocs(state.outdatedDocuments),
           (e) => {
+            captureTransformRawDocsErrors(state.errors, e);
+            // TINA: we don't want to throw here, these errors are never caught
             throw e;
           }
         ),
+        // if we decide to return the CorruptSavedObjectsErrors, the return signature of `transformRawDocs` will change
         TaskEither.chain((docs) =>
           Actions.bulkOverwriteTransformedDocuments(client, state.targetIndex, docs)
         )
@@ -113,8 +125,12 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
   };
 };
 
-export const next = (client: ElasticsearchClient, transformRawDocs: TransformRawDocs) => {
-  const map = nextActionMap(client, transformRawDocs);
+export const next = (
+  client: ElasticsearchClient,
+  transformRawDocs: TransformRawDocs,
+  captureTransformRawDocsErrors: LogCorruptSavedObjectsErrors
+) => {
+  const map = nextActionMap(client, transformRawDocs, captureTransformRawDocsErrors);
   return (state: State) => {
     const delay = <F extends (...args: any) => any>(fn: F): (() => ReturnType<F>) => {
       return () => {

--- a/src/core/server/saved_objects/migrationsv2/next.ts
+++ b/src/core/server/saved_objects/migrationsv2/next.ts
@@ -40,8 +40,6 @@ import {
   DocumentsTransformSuccess,
 } from '../migrations/core/migrate_raw_docs';
 
-// How do i handle this type now that transformRawDocs is actually running migrateRawDocsNonThrowing
-// migrateRawDocsNonThrowing returns an Either.left with failed docs or an Either.right with successfylly processed/transformed docs
 export type TransformRawDocs = (
   processedDocs: SavedObjectsRawDoc[]
 ) => TaskEither.TaskEither<DocumentsTransformFailed, DocumentsTransformSuccess>;
@@ -87,7 +85,7 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
         outdatedDocumentsQuery: state.outdatedDocumentsQuery,
       }),
     OUTDATED_DOCUMENTS_TRANSFORM: (state: OutdatedDocumentsTransform) =>
-      transformRawDocs(state.outdatedDocuments), // one of { processedDocs } or { type: 'document_transform_failed', corruptSavedObjectIds }
+      transformRawDocs(state.outdatedDocuments),
     TRANSFORMED_DOCUMENTS_BULK_INDEX: (state: any) =>
       Actions.bulkOverwriteTransformedDocuments(client, state.targetIndex, state.processedDocs),
     MARK_VERSION_INDEX_READY: (state: MarkVersionIndexReady) =>

--- a/src/core/server/saved_objects/migrationsv2/next.ts
+++ b/src/core/server/saved_objects/migrationsv2/next.ts
@@ -34,13 +34,18 @@ import {
 } from './types';
 import * as Actions from './actions';
 import { ElasticsearchClient } from '../../elasticsearch';
-import { SavedObjectsRawDoc } from '..';
-import { LogCorruptSavedObjectsErrors } from '../migrations/kibana/kibana_migrator';
-import { SavedObjectsRawDocsAndCorruptDocsErrors } from '../migrations/core/migrate_raw_docs';
+import { SavedObjectsRawDoc } from '../serialization';
+import {
+  DocumentsTransformFailed,
+  DocumentsTransformSuccess,
+} from '../migrations/core/migrate_raw_docs';
 
+// How do i handle this type now that transformRawDocs is actually running migrateRawDocsNonThrowing
+// migrateRawDocsNonThrowing returns an Either.left with failed docs or an Either.right with successfylly processed/transformed docs
 export type TransformRawDocs = (
-  rawDocs: SavedObjectsRawDoc[]
-) => Promise<SavedObjectsRawDocsAndCorruptDocsErrors>;
+  processedDocs: SavedObjectsRawDoc[] | { corruptSavedObjectIds: string[]; type: string }
+) => Promise<DocumentsTransformSuccess | DocumentsTransformFailed>;
+
 type ActionMap = ReturnType<typeof nextActionMap>;
 
 /**
@@ -84,23 +89,19 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
     OUTDATED_DOCUMENTS_TRANSFORM: (state: OutdatedDocumentsTransform) =>
       // this needs to change because we're no longer throwing anything from the transformRawDocs method
       TaskEither.tryCatch(
-        () => transformRawDocs(state.outdatedDocuments), // { processDocs, errorsFromTransform}
+        () => transformRawDocs(state.outdatedDocuments), // one of { processedDocs } or { type: 'document_transform_failed', corruptSavedObjectIds }
         (e) => {
-          // we will fail, check if e is a specific case of the transform function failing
-          // then return the response that transforms in migrations failed.
-          // captureTransformRawDocsErrors(state.errors, e);
           // TINA: we throw for realy bad errors
           throw e;
         }
       ),
-    // if we decide to return the CorruptSavedObjectsErrors, the return signature of `transformRawDocs` will change
     TRANSFORMED_DOCUMENTS_BULK_INDEX: (state: any) =>
-      // I need access to the docs that have been processed. I only have stuff from state now.
       // The call to this action was being handled in OUTDATES_DOCUMENTS_TRANSFORM:
       //         TaskEither.chain((docs) =>
       //     Actions.bulkOverwriteTransformedDocuments(client, state.targetIndex, docs)
       //   )
       // ),
+      // How to I get access to the processedDocs now?
       Actions.bulkOverwriteTransformedDocuments(client, state.targetIndex, docs.processedDocs),
     MARK_VERSION_INDEX_READY: (state: MarkVersionIndexReady) =>
       Actions.updateAliases(client, state.versionIndexReadyActions.value),
@@ -125,12 +126,8 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
   };
 };
 
-export const next = (
-  client: ElasticsearchClient,
-  transformRawDocs: TransformRawDocs,
-  captureTransformRawDocsErrors: LogCorruptSavedObjectsErrors
-) => {
-  const map = nextActionMap(client, transformRawDocs, captureTransformRawDocsErrors);
+export const next = (client: ElasticsearchClient, transformRawDocs: TransformRawDocs) => {
+  const map = nextActionMap(client, transformRawDocs);
   return (state: State) => {
     const delay = <F extends (...args: any) => any>(fn: F): (() => ReturnType<F>) => {
       return () => {

--- a/src/core/server/saved_objects/migrationsv2/types.ts
+++ b/src/core/server/saved_objects/migrationsv2/types.ts
@@ -192,7 +192,7 @@ export type OutdatedDocumentsSearch = PostInitState & {
   /** Search for outdated documents in the target index */
   readonly controlState: 'OUTDATED_DOCUMENTS_SEARCH';
 };
-
+// this has changed because we're no longer writing the latest version of the documents to the target index.
 export type OutdatedDocumentsTransform = PostInitState & {
   /** Transform a batch of outdated documents to their latest version and write them to the target index */
   readonly controlState: 'OUTDATED_DOCUMENTS_TRANSFORM';
@@ -280,6 +280,14 @@ export type LegacyDeleteState = LegacyBaseState & {
    * e.g. `.kibana`.
    */
   readonly controlState: 'LEGACY_DELETE';
+};
+
+export type TransformedDocumentsBulkIndex = LegacyBaseState & {
+  /**
+   * Write the up-to-date transformed documents to the index, overwriting any
+   * documents that are still on their outdated version.
+   */
+  readonly controlState: 'TRANSFORMED_DOCUMENTS_BULK_INDEX';
 };
 
 export type State =

--- a/src/core/server/saved_objects/migrationsv2/types.ts
+++ b/src/core/server/saved_objects/migrationsv2/types.ts
@@ -191,6 +191,7 @@ export type UpdateTargetMappingsWaitForTaskState = PostInitState & {
 export type OutdatedDocumentsSearch = PostInitState & {
   /** Search for outdated documents in the target index */
   readonly controlState: 'OUTDATED_DOCUMENTS_SEARCH';
+  readonly failedDocumentIds: string[];
 };
 // this has changed because we're no longer writing the latest version of the documents to the target index.
 export type OutdatedDocumentsTransform = PostInitState & {
@@ -198,6 +199,14 @@ export type OutdatedDocumentsTransform = PostInitState & {
   readonly controlState: 'OUTDATED_DOCUMENTS_TRANSFORM';
   readonly outdatedDocuments: SavedObjectsRawDoc[];
   readonly errors?: Error[];
+  readonly failedDocumentIds: string[];
+};
+export type TransformedDocumentsBulkIndex = PostInitState & {
+  /**
+   * Write the up-to-date transformed documents to the index, overwriting any
+   * documents that are still on their outdated version.
+   */
+  readonly controlState: 'TRANSFORMED_DOCUMENTS_BULK_INDEX';
 };
 
 export type MarkVersionIndexReady = PostInitState & {
@@ -282,14 +291,6 @@ export type LegacyDeleteState = LegacyBaseState & {
   readonly controlState: 'LEGACY_DELETE';
 };
 
-export type TransformedDocumentsBulkIndex = LegacyBaseState & {
-  /**
-   * Write the up-to-date transformed documents to the index, overwriting any
-   * documents that are still on their outdated version.
-   */
-  readonly controlState: 'TRANSFORMED_DOCUMENTS_BULK_INDEX';
-};
-
 export type State =
   | FatalState
   | InitState
@@ -307,6 +308,7 @@ export type State =
   | OutdatedDocumentsTransform
   | MarkVersionIndexReady
   | MarkVersionIndexReadyConflict
+  | TransformedDocumentsBulkIndex
   | LegacyCreateReindexTargetState
   | LegacySetWriteBlockState
   | LegacyReindexState

--- a/src/core/server/saved_objects/migrationsv2/types.ts
+++ b/src/core/server/saved_objects/migrationsv2/types.ts
@@ -197,6 +197,7 @@ export type OutdatedDocumentsTransform = PostInitState & {
   /** Transform a batch of outdated documents to their latest version and write them to the target index */
   readonly controlState: 'OUTDATED_DOCUMENTS_TRANSFORM';
   readonly outdatedDocuments: SavedObjectsRawDoc[];
+  readonly errors?: Error[];
 };
 
 export type MarkVersionIndexReady = PostInitState & {

--- a/src/core/server/saved_objects/migrationsv2/types.ts
+++ b/src/core/server/saved_objects/migrationsv2/types.ts
@@ -193,7 +193,7 @@ export type OutdatedDocumentsSearch = PostInitState & {
   readonly controlState: 'OUTDATED_DOCUMENTS_SEARCH';
   readonly failedDocumentIds: string[];
 };
-// this has changed because we're no longer writing the latest version of the documents to the target index.
+
 export type OutdatedDocumentsTransform = PostInitState & {
   /** Transform a batch of outdated documents to their latest version and write them to the target index */
   readonly controlState: 'OUTDATED_DOCUMENTS_TRANSFORM';


### PR DESCRIPTION
Throw-away PR for collaboration.

Approach:
- collect ids from saved objects that can't be transformed because of a `CorruptSavedObjectError` that we used to throw
- Return either the transformed saved objects or an array of the failed doc ids
- Rework the state machine logic:
	- If all the docs could be transformed, index them and continue with searching for outdated docs (assuming we have PIT searches by then to not search again for outdated docs)
	- If some docs failed, we don't index the ones that did transform, instead, we continue transforming the remaining outdated docs and build up a list of docs that couldn't be transformed.
Eventually, we'll either end the migration successfully, or throw with the full list of docs that have issues.

Current status: Type issues, working the new `migrateRawDocsNonBlocking` implementation for `transformRawDocs` into the state machine.