### PR TITLE
Demo only: sets `managed: true` on importing saved objects from SOM

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/import.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/import.ts
@@ -110,6 +110,7 @@ export const registerImportRoute = (
           overwrite,
           createNewCopies,
           compatibilityMode,
+          managed: true,
         });
 
         return res.ok({ body: result });

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/resolve_import_errors.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/resolve_import_errors.ts
@@ -126,6 +126,7 @@ export const registerResolveImportErrorsRoute = (
           retries: req.body.retries,
           createNewCopies,
           compatibilityMode,
+          managed: true,
         });
 
         return res.ok({ body: result });


### PR DESCRIPTION
This PR is a demo of how setting `managed: true` in `SavedObjectsImportOptions` behaves.

Sets `managed:true` by default for both import and resolve import errors.
All saved objects imported through the Saved Object Management plugin will have their `managed` property set to true.

There isn't a way to declare this option through the Saved Objects HTTP APIs. The option is restricted to plugins only.

[skip-ci]