### PR TITLE
Implements downward compatible update to support mixed kibana versions

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/index.ts
@@ -17,6 +17,7 @@ export { performFind } from './find';
 export { performBulkGet } from './bulk_get';
 export { performGet } from './get';
 export { performUpdate } from './update';
+// export { performBWCUpdate } from './update_bwc';
 export { performBulkUpdate } from './bulk_update';
 export { performRemoveReferencesTo } from './remove_references_to';
 export { performOpenPointInTime } from './open_point_in_time';

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/internals/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/internals/index.ts
@@ -13,3 +13,9 @@ export {
   type InternalBulkResolveParams,
   type InternalSavedObjectsBulkResolveResponse,
 } from './internal_bulk_resolve';
+export {
+  type InternalUpsertParams,
+  type SavedObjectInternalUpsertResponse,
+  // internalUpsert,
+} from './internal_upsert';
+export { type InternalUpdateParams, internalUpdate } from './internal_update';

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/internals/internal_update.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/internals/internal_update.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { isNotFoundFromUnsupportedServer } from '@kbn/core-elasticsearch-server-internal';
+import { MutatingOperationRefreshSetting } from '@kbn/core-saved-objects-api-server/src/apis';
+import { decodeRequestVersion } from '@kbn/core-saved-objects-base-server-internal';
+import {
+  type ISavedObjectsSerializer,
+  SavedObjectSanitizedDoc,
+  SavedObjectsErrorHelpers,
+  SavedObjectReference,
+  SavedObject,
+} from '@kbn/core-saved-objects-server';
+import { cloneDeep } from 'lodash';
+import type { RepositoryEsClient } from '../../repository_es_client';
+
+import type { RepositoryHelpers } from '../helpers';
+import { getCurrentTime } from '../utils';
+
+export interface InternalUpdateParams<T = unknown> {
+  // so info
+  type: string;
+  id: string;
+  namespace?: string;
+  references?: SavedObjectReference[];
+  migrationVersionCompatibility?: 'compatible' | 'raw';
+  version?: string;
+  // apiContext
+  helpers: RepositoryHelpers;
+  client: RepositoryEsClient;
+  serializer: ISavedObjectsSerializer;
+  // update request & options. attributes are the ones we want to replace in the original doc
+  attributes: T;
+  refresh: MutatingOperationRefreshSetting;
+  // doc we retrieved from type & id, migrated to this kibana version
+  migrated: SavedObject<T>;
+}
+
+export const internalUpdate = async <T>({
+  namespace,
+  references,
+  migrationVersionCompatibility,
+  version,
+  helpers,
+  client,
+  serializer,
+  type,
+  id,
+  attributes,
+  refresh,
+  migrated,
+}: InternalUpdateParams): Promise<SavedObjectSanitizedDoc<T>> => {
+  const {
+    common: commonHelper,
+    // validation: validationHelper,
+    encryption: encryptionHelper,
+    migration: migrationHelper,
+  } = helpers;
+
+  const time = getCurrentTime();
+  const originalMigratedDoc = cloneDeep(migrated!) as SavedObject<T>; // `canUpdate` assures we have a doc to work with
+
+  const updatedDoc = {
+    ...migrated,
+    attributes: {
+      ...originalMigratedDoc.attributes,
+      ...(attributes as T),
+    },
+  };
+  const doc = migrationHelper.migrateInputDocument({
+    ...updatedDoc,
+    attributes: {
+      ...(await encryptionHelper.optionallyEncryptAttributes(
+        type,
+        id,
+        namespace,
+        updatedDoc.attributes
+      )),
+    },
+    updated_at: time,
+    ...(Array.isArray(references) && { references }),
+  });
+  // try {
+  //   validationHelper.validateObjectForCreate(type, doc as SavedObjectSanitizedDoc<T>);
+  // } catch (err) {
+  //    swollow error: `coreMigrationVersion` belongs to higher kibana version than current (2.0.0)
+  // kibana version hardcoded to 2.0.0 in repo setup for api unit tests
+  // I can't get around that, even though we ignore the validation for now.
+  // }
+
+  const raw = serializer.savedObjectToRaw(doc as SavedObjectSanitizedDoc<T>);
+
+  const updatedDocRequestParams = {
+    id: raw._id,
+    index: commonHelper.getIndexForType(type),
+    refresh,
+    body: raw._source,
+    ...(version ? decodeRequestVersion(version) : {}),
+    require_alias: true,
+  };
+
+  const {
+    body: indexBody,
+    statusCode: indexStatusCode,
+    headers: indexHeaders,
+  } = await client.index(updatedDocRequestParams, { meta: true });
+
+  if (isNotFoundFromUnsupportedServer({ statusCode: indexStatusCode, headers: indexHeaders })) {
+    throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError(id, type);
+  }
+  // console.log('indexBody', JSON.stringify(indexBody));
+  return serializer.rawToSavedObject<T>(
+    { ...raw, ...indexBody },
+    { migrationVersionCompatibility }
+  );
+};

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/internals/internal_upsert.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/internals/internal_upsert.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { isNotFoundFromUnsupportedServer } from '@kbn/core-elasticsearch-server-internal';
+import { MutatingOperationRefreshSetting } from '@kbn/core-saved-objects-api-server/src/apis';
+import { decodeRequestVersion } from '@kbn/core-saved-objects-base-server-internal';
+import {
+  type ISavedObjectTypeRegistry,
+  type ISavedObjectsSerializer,
+  SavedObjectSanitizedDoc,
+  SavedObjectsErrorHelpers,
+  SavedObjectReference,
+  SavedObjectsRawDoc,
+} from '@kbn/core-saved-objects-server';
+import type { RepositoryEsClient } from '../../repository_es_client';
+
+import type { PreflightCheckNamespacesResult, RepositoryHelpers } from '../helpers';
+/**
+ PerformUpdateBWCParams<T = unknown> {
+  type: string;
+  id: string;
+  attributes: T;
+  options: SavedObjectsUpdateOptions<T>;
+}
+ */
+function validateCreateObject(
+  upsertRawMigrated: SavedObjectsRawDoc,
+  migrationVersionCompatibility?: 'compatible' | 'raw',
+  serializer: ISavedObjectsSerializer,
+  validationHelper: RepositoryHelpers['validation'],
+  type: string
+) {
+  const migratedUnsanitized = serializer.rawToSavedObject(upsertRawMigrated, {
+    migrationVersionCompatibility,
+  });
+  try {
+    validationHelper.validateObjectForCreate(type, migratedUnsanitized);
+  } catch (err) {
+    // ignore the error for now.
+  }
+}
+export interface InternalUpsertParams<T = unknown> {
+  registry: ISavedObjectTypeRegistry;
+  helpers: RepositoryHelpers;
+  client: RepositoryEsClient;
+  serializer: ISavedObjectsSerializer;
+  type: string;
+  id: string;
+  namespace?: string;
+  preflightNamespacesResult?: PreflightCheckNamespacesResult;
+  references?: SavedObjectReference[];
+  // rawUpsert: SavedObjectsRawDoc | undefined;
+  migrationVersionCompatibility?: 'compatible' | 'raw';
+  version?: string;
+  refresh: MutatingOperationRefreshSetting;
+  rawUpsert: T;
+  time: string;
+  migratedInputAttributes: T;
+}
+
+export interface SavedObjectInternalUpsertResponse {
+  savedObject: SavedObjectSanitizedDoc;
+}
+
+// export const internalUpsert = async <T>({
+//   registry,
+//   helpers,
+//   client,
+//   serializer,
+//   type,
+//   id,
+//   namespace,
+//   preflightNamespacesResult,
+//   references,
+//   rawUpsert,
+//   migrationVersionCompatibility,
+//   version,
+//   refresh,
+//   time,
+//   migratedInputAttributes: attributes,
+// }: // upsert,
+// InternalUpsertParams) => {
+//   const {
+//     common: commonHelper,
+//     validation: validationHelper,
+//     encryption: encryptionHelper,
+//   } = helpers;
+
+  const overwrite = true;
+  const migratedUpsertRawDoc = serializer.savedObjectToRaw(rawUpsert as SavedObjectSanitizedDoc);
+
+  // SO repo tests throw on objects with `coreMigrationVersion` against test Kibana version (2.0.0)
+  validateCreateObject(
+    migratedUpsertRawDoc,
+    migrationVersionCompatibility,
+    serializer,
+    validationHelper,
+    type
+  );
+  // attributes here must be migrated to v2 as input args, then merged with the original doc attributes (to overwrite the ones specified in attributes as request body input with the new values also specified in the request body)
+  const doc = {
+    [type]: await encryptionHelper.optionallyEncryptAttributes(type, id, namespace, migratedInputAttributes),
+    updated_at: time,
+    ...(Array.isArray(references) && { references }),
+  };
+  const requestBody = {
+    ...doc,
+    _source: migratedUpsertRawDoc._source,
+    ...(overwrite && version ? decodeRequestVersion(version) : {})
+  }
+  const upsertRequestParams = {
+    id: migratedUpsertRawDoc._id,
+    index: commonHelper.getIndexForType(type),
+    refresh,
+    body: {
+      ...doc,
+      (rawUpsert && migratedUpsertRawDoc._source),
+      ...(overwrite && version ? decodeRequestVersion(version) : {}),
+    },
+    require_alias: true,
+  };
+
+  const {
+    body: createBody,
+    statusCode: createStatusCode,
+    headers: createHeaders,
+  } = await client.create(upsertRequestParams, { meta: true });
+
+  if (isNotFoundFromUnsupportedServer({ statusCode: createStatusCode, headers: createHeaders })) {
+    throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError(id, type);
+  }
+  /**
+   * createBody: WriteResponseBase:
+   * {
+   *   id: Id;
+   *   _index: IndexName;
+   *   _primary_term: long;
+   *   result: Result;
+   *   _seq_no: SequenceNumber;
+   *   _shards: ShardStatistics;
+   *   _version: VersionNumber;
+   *   forced_refresh?: boolean;
+   * }
+   */
+  //
+  return serializer.rawToSavedObject<T>(
+    { ...migratedUpsertRawDoc, ...createBody }, // NB: overwriting _seq_no, _primary_term of the original doc with those from the client & adding _source from originalDoc (after migrating the input args) to the updated doc.
+    { migrationVersionCompatibility }
+  );
+};

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/internals/preflight_check_for_create.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/internals/preflight_check_for_create.ts
@@ -109,13 +109,14 @@ function isMgetDoc(doc?: estypes.MgetResponseItem<unknown>): doc is estypes.GetG
 export async function preflightCheckForCreate(params: PreflightCheckForCreateParams) {
   const { registry, client, serializer, getIndexForType, createPointInTimeFinder, objects } =
     params;
-
+  // console.log('preflightCheckForCreate', JSON.stringify(objects));
   // Step 1: for each object, check if it is over the potential alias threshold; if so, attempt to search for aliases that may be affected.
   // The result is a discriminated union: the left side is 'aliasConflict' errors, and the right side is objects/aliases to bulk-get.
   const aliasConflictsOrObjectsToGet = await optionallyFindAliases(
     createPointInTimeFinder,
     objects
   );
+  // console.log('step 1: aliasConflictsOrObjectsToGet', aliasConflictsOrObjectsToGet);
 
   // Step 2: bulk-get all objects and aliases.
   const objectsAndAliasesToBulkGet = aliasConflictsOrObjectsToGet
@@ -127,7 +128,7 @@ export async function preflightCheckForCreate(params: PreflightCheckForCreatePar
     getIndexForType,
     objectsAndAliasesToBulkGet
   );
-
+  // console.log('step 2: objectsAndAliasesToBulkGet', aliasConflictsOrObjectsToGet);
   // Step 3: process all of the find and bulk-get results, and return appropriate results to the consumer.
   let getResponseIndex = 0;
   let aliasSpacesIndex = 0;
@@ -274,14 +275,12 @@ async function bulkGetObjectsAndAliases(
       }
     }
   }
-
   const bulkGetResponse = docsToBulkGet.length
     ? await client.mget<SavedObjectsRawDocSource>(
         { body: { docs: docsToBulkGet } },
         { ignore: [404], meta: true }
       )
     : undefined;
-
   // throw if we can't verify a 404 response is from Elasticsearch
   if (
     bulkGetResponse &&

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/update.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/update.ts
@@ -108,7 +108,8 @@ export const performUpdate = async <T>(
     } else if (registry.isMultiNamespace(type)) {
       savedObjectNamespaces = preflightResult!.savedObjectNamespaces;
     }
-
+    // create doc: it doesn't exist.
+    // note: es will apply
     const migrated = migrationHelper.migrateInputDocument({
       id,
       type,
@@ -121,7 +122,7 @@ export const performUpdate = async <T>(
     });
     rawUpsert = serializer.savedObjectToRaw(migrated as SavedObjectSanitizedDoc);
   }
-
+  // update existing doc: it exsits
   const doc = {
     [type]: await encryptionHelper.optionallyEncryptAttributes(type, id, namespace, attributes),
     updated_at: time,

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/update_bwc.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/update_bwc.ts
@@ -1,0 +1,308 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  SavedObjectsErrorHelpers,
+  SavedObjectsRawDoc,
+  SavedObjectsRawDocSource,
+  type SavedObject,
+  type SavedObjectSanitizedDoc,
+} from '@kbn/core-saved-objects-server';
+import {
+  SavedObjectsUpdateOptions,
+  SavedObjectsUpdateResponse,
+} from '@kbn/core-saved-objects-api-server';
+import { decodeRequestVersion } from '@kbn/core-saved-objects-base-server-internal';
+import { DEFAULT_REFRESH_SETTING } from '../constants';
+import { getCurrentTime, getSavedObjectFromSource } from './utils';
+import { ApiExecutionContext } from './types';
+import { IValidationHelper, PreflightCheckNamespacesResult } from './helpers';
+import { PreflightGetDocResult } from './helpers/preflight_check';
+import { internalUpdate } from './internals';
+import { isNotFoundFromUnsupportedServer } from '@kbn/core-elasticsearch-server-internal';
+
+export interface PerformUpdateBWCParams<T = unknown> {
+  type: string;
+  id: string;
+  attributes: T;
+  options: SavedObjectsUpdateOptions<T>;
+}
+
+function validateCreateObject(
+  rawUpsert: SavedObjectsRawDoc,
+  validationHelper: IValidationHelper,
+  type: string
+) {
+  const attributes = rawUpsert._source[type];
+  try {
+    validationHelper.validateObjectForCreate(type, attributes);
+  } catch (err) {
+    // ignore throwing the error for now, return pre-defined result type:
+    return {
+      error: 'validation_error',
+      reason: `Request attributes ${attributes} not valid for type ${type}. ${err}`
+    }
+  }
+}
+
+function isUpdateAnOption(
+  preflightNamespacesResult: PreflightCheckNamespacesResult | undefined,
+  preflightGetDocResult: PreflightGetDocResult
+) {
+  if (!preflightNamespacesResult && preflightGetDocResult.checkDocFound === 'found') {
+    return true;
+  } else if (
+    preflightNamespacesResult?.checkResult === 'found_in_namespace' &&
+    preflightNamespacesResult.rawDocSource
+  ) {
+    return true;
+  } else return false;
+}
+
+
+export const performBWCUpdate = async <T>(
+  { id, type, attributes, options }: PerformUpdateBWCParams<T>,
+  { registry, helpers, allowedTypes, client, serializer, extensions }: ApiExecutionContext
+): Promise<SavedObjectsUpdateResponse<T>> => {
+  const {
+    common: commonHelper,
+    encryption: encryptionHelper,
+    preflight: preflightHelper,
+    migration: migrationHelper,
+    validation: validationHelper,
+  } = helpers;
+  const { securityExtension } = extensions;
+
+  const namespace = commonHelper.getCurrentNamespace(options.namespace);
+  // 1. ensure valid request
+  if (!allowedTypes.includes(type)) {
+    throw SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);
+  }
+  if (!id) {
+    throw SavedObjectsErrorHelpers.createBadRequestError('id cannot be empty');
+  }
+
+  const {
+    version,
+    references,
+    upsert,
+    refresh = DEFAULT_REFRESH_SETTING,
+    // retryOnConflict = version ? 0 : DEFAULT_RETRY_COUNT, // not an option for `create/index`
+    migrationVersionCompatibility,
+  } = options;
+
+  // 2. get doc
+  // @TINA TODO: check the preflightGetDoc only returns or throws.
+  const preflightGetDocResult: PreflightGetDocResult = await preflightHelper.preflightGetDoc({
+    type,
+    id,
+    namespace,
+  });
+  // here we have a valid doc result
+  // 3. migrate to this Kibana version
+  let migrated: SavedObject<T>;
+
+  let savedObjectResponse: SavedObjectSanitizedDoc<T>;
+
+  if (
+    preflightGetDocResult.checkDocFound === 'found' &&
+    preflightGetDocResult.unsafeRawDoc !== undefined
+  ) {
+    const rawDocSource = getSavedObjectFromSource<T>(
+      registry,
+      type,
+      id,
+      preflightGetDocResult.unsafeRawDoc,
+      {
+        migrationVersionCompatibility,
+      }
+    );
+
+    // error case: migrating storage doc fails -> general error (500): 'Failed to migrate document to the latest version.'
+    try {
+      migrated = migrationHelper.migrateStorageDocument(rawDocSource) as SavedObject<T>;
+    } catch (error) {
+      throw SavedObjectsErrorHelpers.decorateGeneralError(
+        error,
+        'Failed to migrate document to the latest version.'
+      );
+    }
+  }
+  // TODO NEXT BEFORE DOING ANAYTHING ELSE: in-client update attributes
+  // the original doc will be in v2 (version we need to give client)
+  // take the attr from that and update the ones given in the request.
+  // pass that to the create method
+  // 2023-06-19
+
+  // 4. do Namespaces check if multi-namespace type
+  // note: if preflightNamespacesResult exists, it implies the type is multi-namespace
+  // returns: checkResult & savedObjectNamespaces if checkResult is not found_outside_namespace.
+  let preflightNamespacesResult: PreflightCheckNamespacesResult | undefined;
+
+  if (registry.isMultiNamespace(type)) {
+    // console.log('multinamespace', registry.isMultiNamespace(type));
+    preflightNamespacesResult = await preflightHelper.preflightCheckNamespacesForUpdate({
+      type,
+      id,
+      namespace,
+      rawDocSource: preflightGetDocResult.unsafeRawDoc,
+    });
+  }
+
+  const existingNamespaces =
+    (preflightNamespacesResult && preflightNamespacesResult?.savedObjectNamespaces) ?? [];
+  // auth and audit logging for update for Kibana auth, happens before request to client
+
+  const authorizationResult = await securityExtension?.authorizeUpdate({
+    namespace,
+    object: { type, id, existingNamespaces },
+  });
+  /** condition 1: upsert is ingored if the doc exists:with upsert, we can't create a new doc that already exists and will fall back to trying to update the existing doc BUT it doesn't exist in the CURRENT space, so we can't do anything. not including upsert for updating a multinamespace doc when falling back to update for multinamespace types implies these objects can be updated accross space (doc doesn't exist in the current namespace but we can still update it from here)
+  - condition 2: Specifically for Not trying upsert in the first place: we can't update something that doesn't exist.
+  -- condition 3: singlenamespace types: can't use update if obj does not exist. We can still create it with upsert.
+   */
+  if (
+    preflightNamespacesResult?.checkResult === 'found_outside_namespace' ||
+    (!upsert && preflightNamespacesResult?.checkResult === 'not_found') || //
+    (!registry.isMultiNamespace(type) &&
+      !upsert &&
+      preflightGetDocResult?.checkDocFound === 'not_found')
+  ) {
+    throw SavedObjectsErrorHelpers.createGenericNotFoundError(type, id); // covers case for can't update and where upsert isn't given
+  }
+
+  if (upsert && preflightNamespacesResult?.checkResult === 'not_found') {
+    // If an upsert would result in the creation of a new object, we need to check for alias conflicts too.
+    // This takes an extra round trip to Elasticsearch, but this won't happen often.
+    // TODO: improve performance by combining these into a single preflight check
+    await preflightHelper.preflightCheckForUpsertAliasConflict(type, id, namespace);
+  }
+  /**
+   * upsert is ingored if the doc exists. If if upsert is also specified, we simply don't set rawUpsert if a doc that can be updated exists where it needs to.
+   */
+  let rawUpsert: SavedObjectsRawDoc | undefined; // only defined when all pre-checks are done and it's safe to create the doc. Holds tru for both multi-namespace and other namespace types.
+  const time = getCurrentTime();
+
+  // adds migrated `upsert` to `rawUpsert` if the doc doesn't exist and upsert is declared.
+  // in this case, we don't update the doc, we create it.
+  if (
+    upsert &&
+    (!preflightNamespacesResult || preflightNamespacesResult.checkResult === 'not_found')
+  ) {
+    let savedObjectNamespace: string | undefined;
+    let savedObjectNamespaces: string[] | undefined;
+
+    if (
+      registry.isSingleNamespace(type) &&
+      preflightGetDocResult?.checkDocFound === 'not_found' &&
+      namespace
+    ) {
+      savedObjectNamespace = namespace;
+    } else if (registry.isMultiNamespace(type)) {
+      savedObjectNamespaces = preflightNamespacesResult!.savedObjectNamespaces;
+    }
+
+    // there's a bunch of other fields SO used in create (typeMigrationVersion, migrationVersion etc) but we don't have these here.
+    // can we leave them out?
+
+    const migratedUpsert = migrationHelper.migrateInputDocument({
+      id,
+      type,
+      ...(savedObjectNamespace && { namespace: savedObjectNamespace }),
+      ...(savedObjectNamespaces && { namespaces: savedObjectNamespaces }),
+      attributes: {
+        ...(await encryptionHelper.optionallyEncryptAttributes(type, id, namespace, upsert)),
+      },
+      created_at: time,
+      updated_at: time,
+      ...(Array.isArray(references) && { references }),
+    });
+
+    rawUpsert = serializer.savedObjectToRaw(migratedUpsert as SavedObjectSanitizedDoc);
+    // validate object creation for current version:
+    // SO repo tests throw on objects with `coreMigrationVersion` against test Kibana version (2.0.0)
+    validateCreateObject(rawUpsert, validationHelper, type);
+  }
+
+  let updatedRawDoc: SavedObjectsRawDoc | undefined;
+
+  if (
+    (registry.isMultiNamespace(type) && preflightNamespacesResult?.checkResult === 'found_in_namespace' && preflightGetDocResult.unsafeRawDoc) ||
+    (preflightGetDocResult.checkDocFound === 'found')
+    ) {
+      const { unsafeRawDoc } = preflightGetDocResult;
+      // client-side update. What else do we need here? How do we handle the version
+      const rawDoc = {
+        ...unsafeRawDoc,
+        _source: {
+          ...unsafeRawDoc?._source,
+          [type]: {
+            ...await encryptionHelper.optionallyEncryptAttributes(type, id, namespace, migrated!.attributes),
+            ...await encryptionHelper.optionallyEncryptAttributes(type, id, namespace, attributes),
+          },
+        },
+        updated_at: time,
+        ...(Array.isArray(references) && { references }),
+        }
+      updatedRawDoc = rawDoc
+      }
+
+  // ORIGINAL UPDATE CREATE DOC THAT GET'S ES TO DO THE UPDATE
+  // const updateSavedObjectDoc = {
+  //   [type]: await encryptionHelper.optionallyEncryptAttributes(type, id, namespace, attributes),
+  //   updated_at: time,
+  //   ...(Array.isArray(references) && { references }),
+  // };
+
+  // implement body of upsert as performUpsertAsCreate in internals
+  if (upsert && rawUpsert && ) {
+    const requestParams = {
+      id: rawUpsert!._id,
+      index: commonHelper.getIndexForType(type),
+      refresh,
+      body: rawUpsert!._source,
+      ...(version ? decodeRequestVersion(version) : {}),
+      require_alias: true,
+    };
+    const {
+      body,
+      statusCode,
+      headers,
+    } = await client.create(requestParams, { meta: true, });
+
+    if (isNotFoundFromUnsupportedServer({ statusCode, headers })) {
+    throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError(id, type);
+  }
+    return encryptionHelper.optionallyDecryptAndRedactSingleResult(
+    serializer.rawToSavedObject<T>({ ...rawUpsert, ...body }, { migrationVersionCompatibility }),
+    authorizationResult?.typeMap,
+    attributes
+  );
+  } else if (!upsert && isUpdateAnOption(preflightNamespacesResult, preflightGetDocResult)) {
+    savedObjectResponse = await internalUpdate({
+      helpers,
+      client,
+      serializer,
+      type,
+      id,
+      namespace,
+      references,
+      migrationVersionCompatibility,
+      version,
+      refresh,
+      attributes,
+      migrated: migrated!,
+    });
+  }
+
+  return encryptionHelper.optionallyDecryptAndRedactSingleResult(
+    serializer.rawToSavedObject<T>({ ...rawUpsert, ... }, { migrationVersionCompatibility }),
+    authorizationResult?.typeMap,
+    attributes
+  );
+};

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repository.test.mock.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repository.test.mock.ts
@@ -12,6 +12,7 @@ import type * as InternalUtils from './apis/utils/internal_utils';
 import type { preflightCheckForCreate } from './apis/internals/preflight_check_for_create';
 import type { updateObjectsSpaces } from './apis/internals/update_objects_spaces';
 import type { deleteLegacyUrlAliases } from './apis/internals/delete_legacy_url_aliases';
+import { internalUpdate } from './apis/internals';
 
 export const mockCollectMultiNamespaceReferences = jest.fn() as jest.MockedFunction<
   typeof collectMultiNamespaceReferences
@@ -72,3 +73,8 @@ jest.mock('./apis/internals/delete_legacy_url_aliases', () => ({
 
 export const mockGetSearchDsl = jest.fn();
 jest.mock('./search/search_dsl', () => ({ getSearchDsl: mockGetSearchDsl }));
+
+export const mockInternalUpdate = jest.fn() as jest.MockedFunction<typeof internalUpdate>;
+jest.mock('./apis/internals/internal_update', () => ({
+  internalUpdate: mockInternalUpdate,
+}));

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repository.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repository.ts
@@ -85,6 +85,7 @@ import {
   performResolve,
   performUpdateObjectsSpaces,
   performCollectMultiNamespaceReferences,
+  performBWCUpdate,
 } from './apis';
 import { createRepositoryHelpers } from './utils';
 
@@ -414,6 +415,27 @@ export class SavedObjectsRepository implements ISavedObjectsRepository {
       this.apiExecutionContext
     );
   }
+
+  // /**
+  //  * {@inheritDoc ISavedObjectsRepository.updateBWC}
+  //  */
+  // async updateBWC<T = unknown>(
+  //   type: string,
+  //   id: string,
+  //   attributes: Partial<T>,
+  //   options: SavedObjectsUpdateOptions<T> = {}
+  // ): Promise<SavedObjectsUpdateResponse<T>> {
+  //   const result = await performBWCUpdate(
+  //     {
+  //       type,
+  //       id,
+  //       attributes,
+  //       options,
+  //     },
+  //     this.apiExecutionContext
+  //   );
+  //   return result;
+  // }
 
   /**
    * {@inheritDoc ISavedObjectsRepository.collectMultiNamespaceReferences}

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repositoryBWCupdate.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repositoryBWCupdate.test.ts
@@ -1,0 +1,620 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/* eslint-disable @typescript-eslint/no-shadow */
+
+import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
+import type { SavedObjectsCreateOptions } from '@kbn/core-saved-objects-api-server';
+import {
+  type SavedObjectUnsanitizedDoc,
+  type SavedObject,
+  type SavedObjectReference,
+} from '@kbn/core-saved-objects-server';
+import { ALL_NAMESPACES_STRING } from '@kbn/core-saved-objects-utils-server';
+import { loggerMock } from '@kbn/logging-mocks';
+import {
+  SavedObjectsSerializer,
+  encodeHitVersion,
+} from '@kbn/core-saved-objects-base-server-internal';
+import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+import * as esKuery from '@kbn/es-query';
+import { errors as EsErrors } from '@elastic/elasticsearch';
+import { kibanaMigratorMock } from '../mocks';
+import { SavedObjectsRepository } from './repository';
+import {
+  pointInTimeFinderMock,
+  mockGetCurrentTime,
+  mockPreflightCheckForCreate,
+  mockGetSearchDsl,
+} from './repository.test.mock';
+
+import {
+  NAMESPACE_AGNOSTIC_TYPE,
+  MULTI_NAMESPACE_ISOLATED_TYPE,
+  HIDDEN_TYPE,
+  mockVersionProps,
+  mockTimestampFields,
+  mockTimestamp,
+  mappings,
+  mockVersion,
+  createRegistry,
+  createDocumentMigrator,
+  getMockGetResponse,
+  createSpySerializer,
+  // updateSuccess,
+  mockUpdateResponse,
+  createBadRequestErrorPayload,
+  createConflictErrorPayload,
+  createGenericNotFoundErrorPayload,
+  updateBWCSuccess,
+} from '../test_helpers/repository.test.common';
+
+const { nodeTypes } = esKuery;
+
+describe('SavedObjectsRepository', () => {
+  let client: ReturnType<typeof elasticsearchClientMock.createElasticsearchClient>;
+  let repository: SavedObjectsRepository;
+  let migrator: ReturnType<typeof kibanaMigratorMock.create>;
+  let logger: ReturnType<typeof loggerMock.create>;
+  let serializer: jest.Mocked<SavedObjectsSerializer>;
+
+  const registry = createRegistry();
+  const documentMigrator = createDocumentMigrator(registry);
+
+  beforeEach(() => {
+    pointInTimeFinderMock.mockClear();
+    client = elasticsearchClientMock.createElasticsearchClient();
+    migrator = kibanaMigratorMock.create();
+    documentMigrator.prepareMigrations();
+    migrator.migrateDocument = jest.fn().mockImplementation(documentMigrator.migrate);
+    migrator.runMigrations = jest.fn().mockResolvedValue([{ status: 'skipped' }]);
+    logger = loggerMock.create();
+
+    // create a mock serializer "shim" so we can track function calls, but use the real serializer's implementation
+    serializer = createSpySerializer(registry);
+
+    const allTypes = registry.getAllTypes().map((type) => type.name);
+    const allowedTypes = [...new Set(allTypes.filter((type) => !registry.isHidden(type)))];
+
+    // @ts-expect-error must use the private constructor to use the mocked serializer
+    repository = new SavedObjectsRepository({
+      index: '.kibana-test',
+      mappings,
+      client,
+      migrator,
+      typeRegistry: registry,
+      serializer,
+      allowedTypes,
+      logger,
+    });
+
+    mockGetCurrentTime.mockReturnValue(mockTimestamp);
+    mockGetSearchDsl.mockClear();
+  });
+
+  describe('#updateBWC', () => {
+    const type = 'index-pattern';
+    const attributes = { title: 'Logstash' };
+    const id = 'logstash-*';
+    const namespace = 'foo-namespace';
+    const references = [
+      {
+        name: 'ref_0',
+        type: 'test',
+        id: '123',
+      },
+    ];
+    const originId = 'some-origin-id';
+
+    beforeEach(() => {
+      mockPreflightCheckForCreate.mockReset();
+      mockPreflightCheckForCreate.mockImplementation(({ objects }) => {
+        return Promise.resolve(objects.map(({ type, id }) => ({ type, id }))); // respond with no errors by default
+      });
+    });
+
+    describe('client calls', () => {
+      it(`should use the ES index action without upsert`, async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes);
+        expect(client.get).toHaveBeenCalled();
+        expect(mockPreflightCheckForCreate).not.toHaveBeenCalled();
+        expect(client.index).toHaveBeenCalledTimes(1);
+      });
+
+      it.only(`should use the ES index action with upsert`, async () => {
+        await updateBWCSuccess(
+          client,
+          repository,
+          registry,
+          MULTI_NAMESPACE_ISOLATED_TYPE,
+          id,
+          attributes,
+          { upsert: true },
+          { mockGetResponseValue: { found: false } as estypes.GetResponse }
+        );
+        expect(client.get).toHaveBeenCalledTimes(1);
+        expect(mockPreflightCheckForCreate).not.toHaveBeenCalled();
+        expect(client.index).toHaveBeenCalledTimes(1);
+
+        // expect(client.create).toHaveBeenCalledTimes(1);
+      });
+
+      it(`should check for alias conflicts if a new multi-namespace object would be created`, async () => {
+        await updateBWCSuccess(
+          client,
+          repository,
+          registry,
+          MULTI_NAMESPACE_ISOLATED_TYPE,
+          id,
+          attributes,
+          { upsert: true },
+          { mockGetResponseValue: { found: false } as estypes.GetResponse }
+        );
+        expect(client.get).toHaveBeenCalledTimes(1);
+        expect(mockPreflightCheckForCreate).toHaveBeenCalledTimes(1);
+        expect(client.update).toHaveBeenCalledTimes(1);
+      });
+
+      it(`defaults to no references array`, async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes);
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: { doc: expect.not.objectContaining({ references: expect.anything() }) },
+          }),
+          expect.anything()
+        );
+      });
+
+      it(`accepts custom references array`, async () => {
+        const test = async (references: SavedObjectReference[]) => {
+          await updateBWCSuccess(client, repository, registry, type, id, attributes, {
+            references,
+          });
+          expect(client.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+              body: { doc: expect.objectContaining({ references }) },
+            }),
+            expect.anything()
+          );
+          client.update.mockClear();
+        };
+        await test(references);
+        await test([{ type: 'foo', id: '42', name: 'some ref' }]);
+        await test([]);
+      });
+
+      it(`uses the 'upsertAttributes' option when specified for a single-namespace type`, async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes, {
+          upsert: {
+            title: 'foo',
+            description: 'bar',
+          },
+        });
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'index-pattern:logstash-*',
+            body: expect.objectContaining({
+              upsert: expect.objectContaining({
+                type: 'index-pattern',
+                'index-pattern': {
+                  title: 'foo',
+                  description: 'bar',
+                },
+              }),
+            }),
+          }),
+          expect.anything()
+        );
+      });
+
+      it(`uses the 'upsertAttributes' option when specified for a multi-namespace type that does not exist`, async () => {
+        const options = { upsert: { title: 'foo', description: 'bar' } };
+        mockUpdateResponse(client, MULTI_NAMESPACE_ISOLATED_TYPE, id, options);
+        await repository.update(MULTI_NAMESPACE_ISOLATED_TYPE, id, attributes, options);
+        expect(client.get).toHaveBeenCalledTimes(1);
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: `${MULTI_NAMESPACE_ISOLATED_TYPE}:logstash-*`,
+            body: expect.objectContaining({
+              upsert: expect.objectContaining({
+                type: MULTI_NAMESPACE_ISOLATED_TYPE,
+                [MULTI_NAMESPACE_ISOLATED_TYPE]: {
+                  title: 'foo',
+                  description: 'bar',
+                },
+              }),
+            }),
+          }),
+          expect.anything()
+        );
+      });
+
+      it(`ignores use the 'upsertAttributes' option when specified for a multi-namespace type that already exists`, async () => {
+        const options = { upsert: { title: 'foo', description: 'bar' } };
+        await updateBWCSuccess(
+          client,
+          repository,
+          registry,
+          MULTI_NAMESPACE_ISOLATED_TYPE,
+          id,
+          attributes,
+          options
+        );
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: `${MULTI_NAMESPACE_ISOLATED_TYPE}:logstash-*`,
+            body: expect.not.objectContaining({
+              upsert: expect.anything(),
+            }),
+          }),
+          expect.anything()
+        );
+      });
+
+      it(`doesn't accept custom references if not an array`, async () => {
+        const test = async (references: unknown) => {
+          // @ts-expect-error references is unknown
+          await updateBWCSuccess(client, repository, registry, type, id, attributes, {
+            references,
+          });
+          expect(client.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+              body: { doc: expect.not.objectContaining({ references: expect.anything() }) },
+            }),
+            expect.anything()
+          );
+          client.update.mockClear();
+        };
+        await test('string');
+        await test(123);
+        await test(true);
+        await test(null);
+      });
+
+      it(`defaults to a refresh setting of wait_for`, async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, { foo: 'bar' });
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            refresh: 'wait_for',
+          }),
+          expect.anything()
+        );
+      });
+
+      it(`does not default to the version of the existing document when type is multi-namespace`, async () => {
+        await updateBWCSuccess(
+          client,
+          repository,
+          registry,
+          MULTI_NAMESPACE_ISOLATED_TYPE,
+          id,
+          attributes,
+          { references }
+        );
+        const versionProperties = {
+          if_seq_no: mockVersionProps._seq_no,
+          if_primary_term: mockVersionProps._primary_term,
+        };
+        expect(client.update).toHaveBeenCalledWith(
+          expect.not.objectContaining(versionProperties),
+          expect.anything()
+        );
+      });
+
+      it(`accepts version`, async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes, {
+          version: encodeHitVersion({ _seq_no: 100, _primary_term: 200 }),
+        });
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({ if_seq_no: 100, if_primary_term: 200 }),
+          expect.anything()
+        );
+      });
+
+      it('default to a `retry_on_conflict` setting of `3` when `version` is not provided', async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes, {});
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({ retry_on_conflict: 3 }),
+          expect.anything()
+        );
+      });
+
+      it('default to a `retry_on_conflict` setting of `0` when `version` is provided', async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes, {
+          version: encodeHitVersion({ _seq_no: 100, _primary_term: 200 }),
+        });
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({ retry_on_conflict: 0, if_seq_no: 100, if_primary_term: 200 }),
+          expect.anything()
+        );
+      });
+
+      it('accepts a `retryOnConflict` option', async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes, {
+          version: encodeHitVersion({ _seq_no: 100, _primary_term: 200 }),
+          retryOnConflict: 42,
+        });
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({ retry_on_conflict: 42, if_seq_no: 100, if_primary_term: 200 }),
+          expect.anything()
+        );
+      });
+
+      it(`prepends namespace to the id when providing namespace for single-namespace type`, async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes, { namespace });
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({ id: expect.stringMatching(`${namespace}:${type}:${id}`) }),
+          expect.anything()
+        );
+      });
+
+      it(`doesn't prepend namespace to the id when providing no namespace for single-namespace type`, async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes, { references });
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({ id: expect.stringMatching(`${type}:${id}`) }),
+          expect.anything()
+        );
+      });
+
+      it(`normalizes options.namespace from 'default' to undefined`, async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes, {
+          references,
+          namespace: 'default',
+        });
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({ id: expect.stringMatching(`${type}:${id}`) }),
+          expect.anything()
+        );
+      });
+
+      it(`doesn't prepend namespace to the id when not using single-namespace type`, async () => {
+        await updateBWCSuccess(
+          client,
+          repository,
+          registry,
+          NAMESPACE_AGNOSTIC_TYPE,
+          id,
+          attributes,
+          {
+            namespace,
+          }
+        );
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: expect.stringMatching(`${NAMESPACE_AGNOSTIC_TYPE}:${id}`),
+          }),
+          expect.anything()
+        );
+
+        client.update.mockClear();
+        await updateBWCSuccess(
+          client,
+          repository,
+          registry,
+          MULTI_NAMESPACE_ISOLATED_TYPE,
+          id,
+          attributes,
+          { namespace }
+        );
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: expect.stringMatching(`${MULTI_NAMESPACE_ISOLATED_TYPE}:${id}`),
+          }),
+          expect.anything()
+        );
+      });
+
+      it(`includes _source_includes when type is multi-namespace`, async () => {
+        await updateBWCSuccess(
+          client,
+          repository,
+          registry,
+          MULTI_NAMESPACE_ISOLATED_TYPE,
+          id,
+          attributes
+        );
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({ _source_includes: ['namespace', 'namespaces', 'originId'] }),
+          expect.anything()
+        );
+      });
+
+      it(`includes _source_includes when type is not multi-namespace`, async () => {
+        await updateBWCSuccess(client, repository, registry, type, id, attributes);
+        expect(client.update).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            _source_includes: ['namespace', 'namespaces', 'originId'],
+          }),
+          expect.anything()
+        );
+      });
+    });
+
+    describe('errors', () => {
+      const expectNotFoundError = async (type: string, id: string) => {
+        await expect(repository.update(type, id, {})).rejects.toThrowError(
+          createGenericNotFoundErrorPayload(type, id)
+        );
+      };
+
+      it(`throws when options.namespace is '*'`, async () => {
+        await expect(
+          repository.update(type, id, attributes, { namespace: ALL_NAMESPACES_STRING })
+        ).rejects.toThrowError(createBadRequestErrorPayload('"options.namespace" cannot be "*"'));
+      });
+
+      it(`throws when type is invalid`, async () => {
+        await expectNotFoundError('unknownType', id);
+        expect(client.update).not.toHaveBeenCalled();
+      });
+
+      it(`throws when type is hidden`, async () => {
+        await expectNotFoundError(HIDDEN_TYPE, id);
+        expect(client.update).not.toHaveBeenCalled();
+      });
+
+      it(`throws when id is empty`, async () => {
+        await expect(repository.update(type, '', attributes)).rejects.toThrowError(
+          createBadRequestErrorPayload('id cannot be empty')
+        );
+        expect(client.update).not.toHaveBeenCalled();
+      });
+
+      it(`throws when ES is unable to find the document during get`, async () => {
+        client.get.mockResolvedValueOnce(
+          elasticsearchClientMock.createSuccessTransportRequestPromise(
+            { found: false } as estypes.GetResponse,
+            undefined
+          )
+        );
+        await expectNotFoundError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
+        expect(client.get).toHaveBeenCalledTimes(1);
+      });
+
+      it(`throws when ES is unable to find the index during get`, async () => {
+        client.get.mockResolvedValueOnce(
+          elasticsearchClientMock.createSuccessTransportRequestPromise({} as estypes.GetResponse, {
+            statusCode: 404,
+          })
+        );
+        await expectNotFoundError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
+        expect(client.get).toHaveBeenCalledTimes(1);
+      });
+
+      it(`throws when type is multi-namespace and the document exists, but not in this namespace`, async () => {
+        const response = getMockGetResponse(
+          registry,
+          { type: MULTI_NAMESPACE_ISOLATED_TYPE, id },
+          namespace
+        );
+        client.get.mockResolvedValueOnce(
+          elasticsearchClientMock.createSuccessTransportRequestPromise(response)
+        );
+        await expectNotFoundError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
+        expect(client.get).toHaveBeenCalledTimes(1);
+      });
+
+      it(`throws when there is an alias conflict from preflightCheckForCreate`, async () => {
+        client.get.mockResolvedValueOnce(
+          elasticsearchClientMock.createSuccessTransportRequestPromise({
+            found: false,
+          } as estypes.GetResponse)
+        );
+        mockPreflightCheckForCreate.mockResolvedValue([
+          { type: 'type', id: 'id', error: { type: 'aliasConflict' } },
+        ]);
+        await expect(
+          repository.update(
+            MULTI_NAMESPACE_ISOLATED_TYPE,
+            id,
+            { attr: 'value' },
+            {
+              upsert: {
+                upsertAttr: 'val',
+                attr: 'value',
+              },
+            }
+          )
+        ).rejects.toThrowError(createConflictErrorPayload(MULTI_NAMESPACE_ISOLATED_TYPE, id));
+        expect(client.get).toHaveBeenCalledTimes(1);
+        expect(mockPreflightCheckForCreate).toHaveBeenCalledTimes(1);
+        expect(client.update).not.toHaveBeenCalled();
+      });
+
+      it(`does not throw when there is a different error from preflightCheckForCreate`, async () => {
+        mockPreflightCheckForCreate.mockResolvedValue([
+          { type: 'type', id: 'id', error: { type: 'conflict' } },
+        ]);
+        await updateBWCSuccess(
+          client,
+          repository,
+          registry,
+          MULTI_NAMESPACE_ISOLATED_TYPE,
+          id,
+          attributes,
+          { upsert: true },
+          { mockGetResponseValue: { found: false } as estypes.GetResponse }
+        );
+        expect(client.get).toHaveBeenCalledTimes(1);
+        expect(mockPreflightCheckForCreate).toHaveBeenCalledTimes(1);
+        expect(client.create).toHaveBeenCalledTimes(1);
+      });
+
+      it(`throws when ES is unable to find the document during update`, async () => {
+        const notFoundError = new EsErrors.ResponseError(
+          elasticsearchClientMock.createApiResponse({
+            statusCode: 404,
+            body: { error: { type: 'es_type', reason: 'es_reason' } },
+          })
+        );
+        client.update.mockResolvedValueOnce(
+          elasticsearchClientMock.createErrorTransportRequestPromise(notFoundError)
+        );
+        await expectNotFoundError(type, id);
+        expect(client.update).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('returns', () => {
+      it(`returns _seq_no and _primary_term encoded as version`, async () => {
+        const result = await updateBWCSuccess(client, repository, registry, type, id, attributes, {
+          namespace,
+          references,
+        });
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            id,
+            type,
+            ...mockTimestampFields,
+            version: mockVersion,
+            attributes,
+            references,
+            namespaces: [namespace],
+          })
+        );
+      });
+
+      it(`includes namespaces if type is multi-namespace`, async () => {
+        const result = await updateBWCSuccess(
+          client,
+          repository,
+          registry,
+          MULTI_NAMESPACE_ISOLATED_TYPE,
+          id,
+          attributes
+        );
+        expect(result).toMatchObject({
+          namespaces: expect.any(Array),
+        });
+      });
+
+      it(`includes namespaces if type is not multi-namespace`, async () => {
+        const result = await updateBWCSuccess(client, repository, registry, type, id, attributes);
+        expect(result).toMatchObject({
+          namespaces: ['default'],
+        });
+      });
+
+      it(`includes originId property if present in cluster call response`, async () => {
+        const result = await updateBWCSuccess(
+          client,
+          repository,
+          registry,
+          type,
+          id,
+          attributes,
+          {},
+          { originId }
+        );
+        expect(result).toMatchObject({ originId });
+      });
+    });
+  });
+});

--- a/packages/core/saved-objects/core-saved-objects-api-server/src/apis/update.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server/src/apis/update.ts
@@ -25,12 +25,14 @@ export interface SavedObjectsUpdateOptions<Attributes = unknown> extends SavedOb
   /** The Elasticsearch Refresh setting for this operation */
   refresh?: MutatingOperationRefreshSetting;
   /** If specified, will be used to perform an upsert if the object doesn't exist */
-  upsert?: Attributes;
+  upsert?: Attributes; // Attributes: Pick<SavedObject, 'attributes'>
   /**
    * The Elasticsearch `retry_on_conflict` setting for this operation.
    * Defaults to `0` when `version` is provided, `3` otherwise.
    */
   retryOnConflict?: number;
+  /** {@link SavedObjectsRawDocParseOptions.migrationVersionCompatibility} */
+  migrationVersionCompatibility?: 'compatible' | 'raw';
 }
 
 /**

--- a/packages/core/saved-objects/core-saved-objects-base-server-internal/src/version/encode_hit_version.ts
+++ b/packages/core/saved-objects/core-saved-objects-base-server-internal/src/version/encode_hit_version.ts
@@ -11,6 +11,22 @@ import { encodeVersion } from './encode_version';
 /**
  * Helper for encoding a version from a "hit" (hits.hits[#] from _search) or
  * "doc" (body from GET, update, etc) object
+ *
+ * @example
+ * GET my-index/_doc/specific_doc_id
+ *
+  {
+    "_index": "my-index",
+    "_id": "specific_doc_id",
+    "_version": 1,
+    "_seq_no": 5039035,
+    "_primary_term": 1,
+    "found": true,
+    "_source": {
+      "foo": "bar"
+      },
+   }
+ *
  */
 export function encodeHitVersion(response: { _seq_no?: number; _primary_term?: number }) {
   return encodeVersion(response._seq_no, response._primary_term);


### PR DESCRIPTION
initial attempts at [downward-compatible SOR update api](https://github.com/elastic/kibana/issues/152807).

Main problem: on startup, fleet crashes, as does Kibana
Reasons: 
- incorrect interpretation of upsert vs update behavior in API
- incorrect unit test refactor
- incorrectly casting types
- messy control flow through API
- and others