### PR TITLE
[WIP] Adds restrictedApi usage stats to use in UA

### DIFF
--- a/examples/routing_example/server/routes/message_routes.ts
+++ b/examples/routing_example/server/routes/message_routes.ts
@@ -30,6 +30,9 @@ export function registerPostMessageRoute(router: IRouter) {
   router.post(
     {
       path: `${POST_MESSAGE_ROUTE_PATH}/{id}`,
+      options: {
+        access: 'internal',
+      },
       validate: {
         params: schema.object({
           // This parameter name matches the one in POST_MESSAGE_ROUTE_PATH: `api/post_message/{id}`.
@@ -63,6 +66,9 @@ export function registerGetMessageByIdRoute(router: IRouter) {
   router.get(
     {
       path: `${INTERNAL_GET_MESSAGE_BY_ID_ROUTE}/{id}`,
+      options: {
+        access: 'internal',
+      },
       validate: {
         params: schema.object({
           id: schema.string(),

--- a/packages/core/deprecations/core-deprecations-common/src/types.ts
+++ b/packages/core/deprecations/core-deprecations-common/src/types.ts
@@ -39,7 +39,7 @@ export interface BaseDeprecationDetails {
    * Predefined types are necessary to reduce having similar definitions with different keywords
    * across kibana deprecations.
    */
-  deprecationType?: 'config' | 'api' | 'feature';
+  deprecationType?: 'config' | 'api' | 'feature' | 'restriction';
   /** (optional) link to the documentation for more details on the deprecation. */
   documentationUrl?: string;
   /** (optional) specify the fix for this deprecation requires a full kibana restart. */
@@ -98,6 +98,13 @@ export interface ApiDeprecationDetails extends BaseDeprecationDetails {
 /**
  * @public
  */
+export interface ApiRestrictionDetails extends BaseDeprecationDetails {
+  apiId: string;
+  deprecationType: 'restriction';
+}
+/**
+ * @public
+ */
 export interface ConfigDeprecationDetails extends BaseDeprecationDetails {
   configPath: string;
   deprecationType: 'config';
@@ -116,7 +123,8 @@ export interface FeatureDeprecationDetails extends BaseDeprecationDetails {
 export type DeprecationsDetails =
   | ConfigDeprecationDetails
   | ApiDeprecationDetails
-  | FeatureDeprecationDetails;
+  | FeatureDeprecationDetails
+  | ApiDeprecationDetails;
 
 /**
  * @public

--- a/packages/core/deprecations/core-deprecations-server-internal/src/deprecations/api_restrictions.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/deprecations/api_restrictions.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { InternalHttpServiceSetup } from '@kbn/core-http-server-internal';
+import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
+import type { RouterRestrictedRouteDetails } from '@kbn/core-http-server';
+import { DeprecationsDetails } from '@kbn/core-deprecations-common';
+import type { DeprecationsFactory } from '../deprecations_factory';
+import {
+  getApiRestrictionMessage,
+  getApiRestrictionsManualSteps,
+  getApiRestrictionTitle,
+} from './i18n_texts';
+
+interface ApiDeprecationsServiceDeps {
+  deprecationsFactory: DeprecationsFactory;
+  http: InternalHttpServiceSetup;
+  coreUsageData: InternalCoreUsageDataSetup;
+}
+
+export const buildApiRestrictionId = ({
+  routePath,
+  routeMethod,
+  routeVersion,
+}: Pick<RouterRestrictedRouteDetails, 'routeMethod' | 'routePath' | 'routeVersion'>): string => {
+  return [
+    routeVersion || 'unversioned',
+    routeMethod.toLocaleLowerCase(),
+    routePath.replace(/\/$/, ''),
+  ].join('|');
+};
+// @TINA WIP
+export const createGetApiRestrictions =
+  ({ http, coreUsageData }: Pick<ApiDeprecationsServiceDeps, 'coreUsageData' | 'http'>) =>
+  async (): Promise<DeprecationsDetails[]> => {
+    const restrictedRoutes = http.getRegisteredRestrictedApis();
+    const usageClient = coreUsageData.getClient();
+    const restrictedApiUsageStats = await usageClient.getRestrictedApiUsageStats();
+
+    return restrictedApiUsageStats
+      .filter(({ apiTotalCalls, totalMarkedAsResolved }) => {
+        return apiTotalCalls > totalMarkedAsResolved;
+      })
+      .filter(({ apiId }) =>
+        restrictedRoutes.some((routeDetails) => buildApiRestrictionId(routeDetails) === apiId)
+      )
+      .map((apiUsageStats) => {
+        const { apiId, apiTotalCalls, totalMarkedAsResolved } = apiUsageStats;
+        const routeRestrictionDetails = restrictedRoutes.find(
+          (routeDetails) => buildApiRestrictionId(routeDetails) === apiId
+        )!;
+        const { routeVersion, routePath, routeMethod, routeRestrictionOptions } =
+          routeRestrictionDetails;
+        const defaultLevel = routeRestrictionOptions.reason.type === 'restricted';
+        const deprecationLevel = routeRestrictionOptions.severity || defaultLevel;
+
+        return {
+          apiId,
+          title: getApiRestrictionTitle(routeRestrictionDetails),
+          level: deprecationLevel,
+          message: getApiRestrictionMessage(routeRestrictionDetails, apiUsageStats),
+          documentationUrl: routeRestrictionOptions.documentationUrl,
+          correctiveActions: {
+            manualSteps: getApiRestrictionsManualSteps(routeRestrictionDetails),
+            mark_as_resolved_api: {
+              routePath,
+              routeMethod,
+              routeVersion,
+              apiTotalCalls,
+              totalMarkedAsResolved,
+              timestamp: new Date(),
+            },
+          },
+          deprecationType: 'api',
+          domainId: 'core.routes-deprecations',
+        };
+      });
+  };
+
+export const registerApiRestrictionsInfo = ({
+  deprecationsFactory,
+  http,
+  coreUsageData,
+}: ApiDeprecationsServiceDeps): void => {
+  const deprecationsRegistery = deprecationsFactory.getRegistry('core.api_deprecations');
+
+  deprecationsRegistery.registerDeprecations({
+    getDeprecations: createGetApiRestrictions({ http, coreUsageData }),
+  });
+};

--- a/packages/core/deprecations/core-deprecations-server-internal/src/deprecations/i18n_texts.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/deprecations/i18n_texts.ts
@@ -7,8 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { RouterDeprecatedRouteDetails } from '@kbn/core-http-server';
-import { CoreDeprecatedApiUsageStats } from '@kbn/core-usage-data-server';
+import { RouterDeprecatedRouteDetails, RouterRestrictedRouteDetails } from '@kbn/core-http-server';
+import {
+  CoreDeprecatedApiUsageStats,
+  CoreRestrictedApiUsageStats,
+} from '@kbn/core-usage-data-server';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
 
@@ -16,17 +19,17 @@ export const getApiDeprecationTitle = (details: RouterDeprecatedRouteDetails) =>
   const { routePath, routeMethod, routeDeprecationOptions } = details;
   const deprecationType = routeDeprecationOptions.reason.type;
   const routeWithMethod = `${routeMethod.toUpperCase()} ${routePath}`;
-  const deprecationTypeText = i18n.translate('core.deprecations.deprecations.apiDeprecationType', {
+  const restrictionTypeText = i18n.translate('core.deprecations.deprecations.apiDeprecationType', {
     defaultMessage:
       '{deprecationType, select, remove {is removed} bump {has a newer version available} migrate {is migrated to a different API} other {is deprecated}}',
     values: { deprecationType },
   });
 
   return i18n.translate('core.deprecations.deprecations.apiDeprecationInfoTitle', {
-    defaultMessage: 'The "{routeWithMethod}" route {deprecationTypeText}',
+    defaultMessage: 'The "{routeWithMethod}" route {restrictionTypeText}',
     values: {
       routeWithMethod,
-      deprecationTypeText,
+      restrictionTypeText,
     },
   });
 };
@@ -125,6 +128,128 @@ export const getApiDeprecationsManualSteps = (details: RouterDeprecatedRouteDeta
     i18n.translate('core.deprecations.deprecations.manualSteps.markAsResolvedStep', {
       defaultMessage:
         'Check that you are no longer using the old API in any requests, and mark this issue as resolved. It will no longer appear in the Upgrade Assistant unless another call using this API is detected.',
+    })
+  );
+
+  return manualSteps;
+};
+
+// @TINA TODO: implement similar getters for apiRestrictions
+export const getApiRestrictionTitle = (details: RouterRestrictedRouteDetails) => {
+  const { routePath, routeMethod } = details;
+  const routeWithMethod = `${routeMethod.toUpperCase()} ${routePath}`;
+  const restrictionTypeText = getApiRestrictionTypeText(details);
+
+  return i18n.translate('core.deprecations.deprecations.apiRestrictionInfoTitle', {
+    defaultMessage: 'The "{routeWithMethod}" route {restrictionTypeText}',
+    values: {
+      routeWithMethod,
+      restrictionTypeText,
+    },
+  });
+};
+
+export const getApiRestrictionTypeText = (details: RouterRestrictedRouteDetails) => {
+  const { routeRestrictionOptions } = details;
+  const deprecationType = routeRestrictionOptions.reason.type;
+
+  return i18n.translate('core.deprecations.deprecations.apiRestrictionType', {
+    defaultMessage: '{deprecationType, select, restricted {is restricted}}',
+    values: { deprecationType },
+  });
+};
+
+export const getApiRestrictionMessage = (
+  details: RouterRestrictedRouteDetails,
+  apiUsageStats: CoreRestrictedApiUsageStats
+) => {
+  const { routePath, routeMethod } = details;
+  const { apiLastCalledAt, apiTotalCalls, markedAsResolvedLastCalledAt, totalMarkedAsResolved } =
+    apiUsageStats;
+
+  const diff = apiTotalCalls - totalMarkedAsResolved;
+  const wasResolvedBefore = totalMarkedAsResolved > 0;
+  const routeWithMethod = `${routeMethod.toUpperCase()} ${routePath}`;
+
+  const messages = [
+    i18n.translate('core.deprecations.deprecations.apiRestrictionApiCallsDetailsMessage', {
+      defaultMessage:
+        'The API {routeWithMethod} has been called {apiTotalCalls} times. The API was last called on {apiLastCalledAt}.',
+      values: {
+        routeWithMethod,
+        apiTotalCalls,
+        apiLastCalledAt: moment(apiLastCalledAt).format('LLLL Z'),
+      },
+    }),
+  ];
+
+  if (wasResolvedBefore) {
+    messages.push(
+      i18n.translate(
+        'core.deprecations.deprecations.apiRestrictionPreviouslyMarkedAsResolvedMessage',
+        {
+          defaultMessage:
+            'This API has been marked as resolved before. It has been called {timeSinceLastResolved} times since it was marked as resolved on {markedAsResolvedLastCalledAt}.',
+          values: {
+            timeSinceLastResolved: diff,
+            markedAsResolvedLastCalledAt: moment(markedAsResolvedLastCalledAt).format('LLLL Z'),
+          },
+        }
+      )
+    );
+  }
+
+  return messages.join('\n');
+};
+
+export const getApiRestrictionsManualSteps = (details: RouterRestrictedRouteDetails): string[] => {
+  const { routeRestrictionOptions, routePath } = details;
+  const { documentationUrl } = routeRestrictionOptions;
+  const restrictionType = routeRestrictionOptions.reason.type;
+
+  const manualSteps = [
+    i18n.translate('core.deprecations.deprecations.manualSteps.apiIsRestrictedStep', {
+      defaultMessage: 'This API {restrictionTypeText}',
+      values: { restrictionTypeText: getApiRestrictionTypeText(details) },
+    }),
+  ];
+
+  switch (restrictionType) {
+    case 'restricted': {
+      manualSteps.push(
+        i18n.translate(
+          'core.deprecations.deprecations.manualSteps.restrictedTypeExplainationStep',
+          {
+            defaultMessage:
+              'A restricted deprecation means the API is restricted and will not be publically accessible.',
+          }
+        ),
+        i18n.translate('core.deprecations.deprecations.manualSteps.restrictedDetailsStep', {
+          defaultMessage: 'This API {routePath} is restricted.',
+          values: { routePath },
+        })
+      );
+      break;
+    }
+  }
+
+  if (documentationUrl) {
+    manualSteps.push(
+      i18n.translate('core.deprecations.deprecations.manualSteps.documentationStep', {
+        defaultMessage:
+          'Click the learn more documentation link for more details on addressing the restricted API.',
+      })
+    );
+  }
+
+  manualSteps.push(
+    i18n.translate('core.deprecations.deprecations.manualSteps.markAsResolvedStep', {
+      defaultMessage:
+        'Once you are no longer using the restricted API. You can click on the "Mark as Resolved" button to track if the API is still getting called.',
+    }),
+    i18n.translate('core.deprecations.deprecations.manualSteps.deprecationWillBeHiddenStep', {
+      defaultMessage:
+        'The deprecation will be hidden from the Upgrade Assistant unless the restricted API has been called again.',
     })
   );
 

--- a/packages/core/deprecations/core-deprecations-server-internal/src/deprecations/index.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/deprecations/index.ts
@@ -8,4 +8,5 @@
  */
 
 export { buildApiDeprecationId, registerApiDeprecationsInfo } from './api_deprecations';
+export { buildApiRestrictionId, registerApiRestrictionsInfo } from './api_restrictions';
 export { registerConfigDeprecationsInfo } from './config_deprecations';

--- a/packages/core/deprecations/core-deprecations-server-internal/src/deprecations_service.test.mocks.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/deprecations_service.test.mocks.ts
@@ -16,10 +16,12 @@ export const DeprecationsFactoryMock = jest
 
 export const registerConfigDeprecationsInfoMock = jest.fn();
 export const registerApiDeprecationsInfoMock = jest.fn();
+export const registerApiRestrictionsInfoMock = jest.fn();
 
 jest.doMock('./deprecations', () => ({
   registerConfigDeprecationsInfo: registerConfigDeprecationsInfoMock,
   registerApiDeprecationsInfo: registerApiDeprecationsInfoMock,
+  registerApiRestrictionsInfo: registerApiRestrictionsInfoMock,
 }));
 
 jest.doMock('./deprecations_factory', () => ({

--- a/packages/core/deprecations/core-deprecations-server-internal/src/deprecations_service.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/deprecations_service.ts
@@ -23,7 +23,11 @@ import { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-int
 import { DeprecationsFactory } from './deprecations_factory';
 import { registerRoutes } from './routes';
 import { config as deprecationConfig, DeprecationConfigType } from './deprecation_config';
-import { registerApiDeprecationsInfo, registerConfigDeprecationsInfo } from './deprecations';
+import {
+  registerApiDeprecationsInfo,
+  registerApiRestrictionsInfo,
+  registerConfigDeprecationsInfo,
+} from './deprecations';
 
 export interface InternalDeprecationsServiceStart {
   /**
@@ -83,6 +87,12 @@ export class DeprecationsService
     });
 
     registerApiDeprecationsInfo({
+      deprecationsFactory: this.deprecationsFactory,
+      http,
+      coreUsageData,
+    });
+
+    registerApiRestrictionsInfo({
       deprecationsFactory: this.deprecationsFactory,
       http,
       coreUsageData,

--- a/packages/core/deprecations/core-deprecations-server-internal/src/routes/post_validation_handler.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/routes/post_validation_handler.ts
@@ -11,23 +11,24 @@ import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-server-int
 import type { CoreKibanaRequest } from '@kbn/core-http-router-server-internal';
 import type { InternalHttpServiceSetup } from '@kbn/core-http-server-internal';
 import { isObject } from 'lodash';
-import { RouteDeprecationInfo } from '@kbn/core-http-server/src/router/route';
-import { buildApiDeprecationId } from '../deprecations';
+import { RouteDeprecationInfo, RouteRestrictionInfo } from '@kbn/core-http-server/src/router/route';
+import { buildApiDeprecationId, buildApiRestrictionId } from '../deprecations';
 
 interface Dependencies {
   coreUsageData: InternalCoreUsageDataSetup;
   http: InternalHttpServiceSetup;
 }
-
+// @Tina TODO: work in buildApiRestrictionId in here
 /**
- * listens to http post validation events to increment deprecated api calls
- * This will keep track of any called deprecated API.
+ * listens to http post validation events to increment deprecated api calls and increment restricted api calls.
+ * This will keep track of any deprecated or restricted APIs called.
  */
 export const registerApiDeprecationsPostValidationHandler = ({
   coreUsageData,
   http,
 }: Dependencies) => {
   http.registerOnPostValidation(createRouteDeprecationsHandler({ coreUsageData }));
+  http.registerOnPostValidation(createRouteRestrictionsHandler({ coreUsageData }));
 };
 
 export function createRouteDeprecationsHandler({
@@ -46,6 +47,28 @@ export function createRouteDeprecationsHandler({
       const client = coreUsageData.getClient();
       // no await we just fire it off.
       void client.incrementDeprecatedApi(counterName, { resolved: false });
+    }
+  };
+}
+
+// @Tina TODO double check this is correct
+export function createRouteRestrictionsHandler({
+  coreUsageData,
+}: {
+  coreUsageData: InternalCoreUsageDataSetup;
+}) {
+  return (req: CoreKibanaRequest, { restricted }: { restricted?: RouteRestrictionInfo }) => {
+    // increase counter on external requests to internal APIs
+    if (!req.isInternalApiRequest && restricted && isObject(restricted) && req.route.routePath) {
+      const counterName = buildApiRestrictionId({
+        routeMethod: req.route.method,
+        routePath: req.route.routePath,
+        routeVersion: req.apiVersion,
+      });
+
+      const client = coreUsageData.getClient();
+      // no await we just fire it off.
+      void client.incrementRestrictedApi(counterName, { resolved: false });
     }
   };
 }

--- a/packages/core/deprecations/core-deprecations-server-internal/src/routes/resolve_deprecated_api.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/routes/resolve_deprecated_api.ts
@@ -10,8 +10,8 @@
 import { schema } from '@kbn/config-schema';
 import { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { InternalDeprecationRouter } from '../internal_types';
-import { buildApiDeprecationId } from '../deprecations';
-
+import { buildApiDeprecationId, buildApiRestrictionId } from '../deprecations';
+// @Tina TODO refactor to reuse for restrictedApiRequests
 export const registerMarkAsResolvedRoute = (
   router: InternalDeprecationRouter,
   { coreUsageData }: { coreUsageData: InternalCoreUsageDataSetup }
@@ -45,7 +45,20 @@ export const registerMarkAsResolvedRoute = (
         routeVersion,
       });
 
-      await usageClient.incrementDeprecatedApi(counterName, { resolved: true, incrementBy });
+      const restrictionCounterName = buildApiRestrictionId({
+        routeMethod,
+        routePath,
+        routeVersion,
+      });
+
+      await usageClient.incrementDeprecatedApi(counterName, {
+        resolved: true,
+        incrementBy,
+      });
+      await usageClient.incrementRestrictedApi(restrictionCounterName, {
+        resolved: true,
+        incrementBy,
+      });
       return res.ok();
     }
   );

--- a/packages/core/http/core-http-server-internal/src/http_service.ts
+++ b/packages/core/http/core-http-server-internal/src/http_service.ts
@@ -189,6 +189,7 @@ export class HttpService
         Router.on('onPostValidate', cb);
       },
       getRegisteredDeprecatedApis: () => serverContract.getDeprecatedRoutes(),
+      getRegisteredRestrictedApis: () => serverContract.getRestrictedRoutes(),
       externalUrl: new ExternalUrlConfig(config.externalUrl),
       createRouter: <Context extends RequestHandlerContextBase = RequestHandlerContextBase>(
         path: string,

--- a/packages/core/http/core-http-server-internal/src/types.ts
+++ b/packages/core/http/core-http-server-internal/src/types.ts
@@ -17,9 +17,10 @@ import type {
   HttpServiceSetup,
   HttpServiceStart,
   RouterDeprecatedRouteDetails,
+  RouterRestrictedRouteDetails,
 } from '@kbn/core-http-server';
 import { CoreKibanaRequest } from '@kbn/core-http-router-server-internal';
-import { RouteDeprecationInfo } from '@kbn/core-http-server/src/router/route';
+import { RouteDeprecationInfo, RouteRestrictionInfo } from '@kbn/core-http-server/src/router/route';
 import type { HttpServerSetup } from './http_server';
 import type { ExternalUrlConfig } from './external_url';
 import type { InternalStaticAssets } from './static_assets';
@@ -58,7 +59,10 @@ export interface InternalHttpServiceSetup
     plugin?: PluginOpaqueId
   ) => IRouter<Context>;
   registerOnPostValidation(
-    cb: (req: CoreKibanaRequest, metadata: { deprecated: RouteDeprecationInfo }) => void
+    cb: (
+      req: CoreKibanaRequest,
+      metadata: { deprecated?: RouteDeprecationInfo; restricted?: RouteRestrictionInfo }
+    ) => void
   ): void;
   registerRouterAfterListening: (router: IRouter) => void;
   registerStaticDir: (path: string, dirPath: string) => void;
@@ -72,6 +76,7 @@ export interface InternalHttpServiceSetup
     provider: IContextProvider<Context, ContextName>
   ) => IContextContainer;
   getRegisteredDeprecatedApis: () => RouterDeprecatedRouteDetails[];
+  getRegisteredRestrictedApis: () => RouterRestrictedRouteDetails[];
 }
 
 /** @internal */

--- a/packages/core/http/core-http-server/index.ts
+++ b/packages/core/http/core-http-server/index.ts
@@ -94,6 +94,7 @@ export type {
   RouteRegistrar,
   RouterRoute,
   RouterDeprecatedRouteDetails,
+  RouterRestrictedRouteDetails,
   IKibanaSocket,
   KibanaErrorResponseFactory,
   KibanaRedirectionResponseFactory,

--- a/packages/core/http/core-http-server/src/http_contract.ts
+++ b/packages/core/http/core-http-server/src/http_contract.ts
@@ -13,6 +13,7 @@ import type {
   IRouter,
   RequestHandlerContextBase,
   RouterDeprecatedRouteDetails,
+  RouterRestrictedRouteDetails,
 } from './router';
 import type {
   AuthenticationHandler,
@@ -368,6 +369,15 @@ export interface HttpServiceSetup<
    * @returns {RouterDeprecatedRouteDetails[]}
    */
   getDeprecatedRoutes: () => RouterDeprecatedRouteDetails[];
+
+  // /**
+  //  * Provides a list of all registered restricted routes {{@link RouterRestrictedRouteDetails | information}}.
+  //  * The routers will be evaluated everytime this function gets called to
+  //  * accommodate for any late route registrations
+  //  * @returns {RouterRestrictedRouteDetails[]}
+  //  */
+  // @Tina TODO fix up, we're not adding `restricted` to versioned routes because we already have the `access` parameter set in route.options.
+  getRestrictedRoutes: () => RouterRestrictedRouteDetails[];
 }
 
 /** @public */

--- a/packages/core/http/core-http-server/src/router/index.ts
+++ b/packages/core/http/core-http-server/src/router/index.ts
@@ -80,7 +80,13 @@ export type {
   LazyValidator,
 } from './route_validator';
 export { RouteValidationError } from './route_validator';
-export type { IRouter, RouteRegistrar, RouterRoute, RouterDeprecatedRouteDetails } from './router';
+export type {
+  IRouter,
+  RouteRegistrar,
+  RouterRoute,
+  RouterDeprecatedRouteDetails,
+  RouterRestrictedRouteDetails,
+} from './router';
 export type { IKibanaSocket } from './socket';
 export type {
   KibanaErrorResponseFactory,

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -126,6 +126,18 @@ export interface RouteDeprecationInfo {
 }
 
 /**
+ * Route Restriction info
+ * This information will assist Kibana HTTP API users when upgrading to new versions
+ * of the Elastic stack (via Upgrade Assistant)
+ */
+export interface RouteRestrictionInfo {
+  documentationUrl: string;
+  severity: 'warning' | 'critical';
+  reason: {
+    type: 'restricted';
+  };
+}
+/**
  * bump deprecation reason denotes a new version of the API is available
  */
 interface VersionBumpDeprecationType {

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -132,7 +132,7 @@ export interface RouteDeprecationInfo {
  */
 export interface RouteRestrictionInfo {
   documentationUrl: string;
-  severity: 'warning' | 'critical';
+  severity: 'warning' | 'critical'; // warn when restriction disabled, critical when restriction enabled (default)
   reason: {
     type: 'restricted';
   };

--- a/packages/core/http/core-http-server/src/router/router.ts
+++ b/packages/core/http/core-http-server/src/router/router.ts
@@ -10,7 +10,7 @@
 import type { Request, ResponseObject, ResponseToolkit } from '@hapi/hapi';
 import type Boom from '@hapi/boom';
 import type { VersionedRouter } from '../versioning';
-import type { RouteConfig, RouteDeprecationInfo, RouteMethod } from './route';
+import type { RouteConfig, RouteDeprecationInfo, RouteMethod, RouteRestrictionInfo } from './route';
 import type { RequestHandler, RequestHandlerWrapper } from './request_handler';
 import type { RequestHandlerContextBase } from './request_handler_context';
 import type { RouteConfigOptions } from './route';
@@ -149,3 +149,26 @@ export interface RouterDeprecatedRouteDetails {
   routePath: string;
   routeVersion?: string;
 }
+
+// @TINA verify we need this as an object, http_server's not happy with this
+/** @public */
+export interface RouterRestrictedRouteDetails {
+  routeRestrictionOptions: RouteRestrictionInfo;
+  routeMethod: RouteMethod;
+  routePath: string;
+  routeVersion?: string;
+}
+/**
+RouterRestriedRouteDetails {
+  routeRestrictionOptions: {
+    documentationUrl: string;
+    severity: 'warning' | 'critical';
+    reason: {
+      type: 'restricted';
+    }
+  },
+  routeMethod: 'get',
+  routePath: '/api/something',
+  routeVersion?
+}
+*/

--- a/packages/core/plugins/core-plugins-server-internal/src/plugin_context.ts
+++ b/packages/core/plugins/core-plugins-server-internal/src/plugin_context.ts
@@ -226,6 +226,7 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>({
     http: {
       createCookieSessionStorageFactory: deps.http.createCookieSessionStorageFactory,
       getDeprecatedRoutes: deps.http.getDeprecatedRoutes,
+      getRestrictedRoutes: deps.http.getRestrictedRoutes,
       registerRouteHandlerContext: <
         Context extends RequestHandlerContext,
         ContextName extends keyof Omit<Context, 'resolve'>
@@ -285,6 +286,7 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>({
     coreUsageData: {
       registerUsageCounter: deps.coreUsageData.registerUsageCounter,
       registerDeprecatedUsageFetch: deps.coreUsageData.registerDeprecatedUsageFetch,
+      registerRestrictedUsageFetch: deps.coreUsageData.registerRestrictedUsageFetch,
     },
     plugins: {
       onSetup: (...dependencyNames) => runtimeResolver.onSetup(plugin.name, dependencyNames),

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/mocks/internal_mocks.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/mocks/internal_mocks.ts
@@ -37,6 +37,7 @@ export const createCoreUsageDataSetupMock = () => {
     registerUsageCounter: jest.fn(),
     incrementUsageCounter: jest.fn(),
     registerDeprecatedUsageFetch: jest.fn(),
+    registerRestrictedUsageFetch: jest.fn(),
   };
   return setupContract;
 };

--- a/packages/core/usage-data/core-usage-data-base-server-internal/src/usage_stats_client.ts
+++ b/packages/core/usage-data/core-usage-data-base-server-internal/src/usage_stats_client.ts
@@ -8,7 +8,11 @@
  */
 
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { CoreUsageStats, CoreDeprecatedApiUsageStats } from '@kbn/core-usage-data-server';
+import type {
+  CoreUsageStats,
+  CoreDeprecatedApiUsageStats,
+  CoreRestrictedApiUsageStats,
+} from '@kbn/core-usage-data-server';
 
 /** @internal */
 export interface BaseIncrementOptions {
@@ -41,6 +45,13 @@ export interface ICoreUsageStatsClient {
   getDeprecatedApiUsageStats(): Promise<CoreDeprecatedApiUsageStats[]>;
 
   incrementDeprecatedApi(
+    counterName: string,
+    options: { resolved?: boolean; incrementBy?: number }
+  ): Promise<void>;
+
+  getRestrictedApiUsageStats(): Promise<CoreRestrictedApiUsageStats[]>;
+
+  incrementRestrictedApi(
     counterName: string,
     options: { resolved?: boolean; incrementBy?: number }
   ): Promise<void>;

--- a/packages/core/usage-data/core-usage-data-server-internal/src/core_usage_stats_client.test.ts
+++ b/packages/core/usage-data/core-usage-data-server-internal/src/core_usage_stats_client.test.ts
@@ -53,6 +53,7 @@ describe('CoreUsageStatsClient', () => {
       basePath: basePathMock,
       repositoryPromise: Promise.resolve(repositoryMock),
       fetchDeprecatedUsageStats: jest.fn(),
+      fetchRestrictedUsageStats: jest.fn(),
       stop$,
       incrementUsageCounter: incrementUsageCounterMock,
     });

--- a/packages/core/usage-data/core-usage-data-server-mocks/src/core_usage_data_service.mock.ts
+++ b/packages/core/usage-data/core-usage-data-server-mocks/src/core_usage_data_service.mock.ts
@@ -18,6 +18,7 @@ const createSetupContractMock = (usageStatsClient = coreUsageStatsClientMock.cre
   const setupContract: jest.Mocked<InternalCoreUsageDataSetup> = {
     registerType: jest.fn(),
     registerDeprecatedUsageFetch: jest.fn(),
+    registerRestrictedUsageFetch: jest.fn(),
     getClient: jest.fn().mockReturnValue(usageStatsClient),
     registerUsageCounter: jest.fn(),
     incrementUsageCounter: jest.fn(),

--- a/packages/core/usage-data/core-usage-data-server-mocks/src/core_usage_stats_client.mock.ts
+++ b/packages/core/usage-data/core-usage-data-server-mocks/src/core_usage_stats_client.mock.ts
@@ -13,6 +13,7 @@ const createUsageStatsClientMock = () =>
   ({
     getUsageStats: jest.fn().mockResolvedValue({}),
     getDeprecatedApiUsageStats: jest.fn().mockResolvedValue([]),
+    getRestrictedApiUsageStats: jest.fn().mockResolvedValue([]),
     incrementSavedObjectsBulkCreate: jest.fn().mockResolvedValue(null),
     incrementSavedObjectsBulkGet: jest.fn().mockResolvedValue(null),
     incrementSavedObjectsBulkResolve: jest.fn().mockResolvedValue(null),

--- a/packages/core/usage-data/core-usage-data-server/index.ts
+++ b/packages/core/usage-data/core-usage-data-server/index.ts
@@ -20,5 +20,7 @@ export type {
   CoreServicesUsageData,
   CoreUsageStats,
   CoreDeprecatedApiUsageStats,
+  CoreRestrictedApiUsageStats,
   DeprecatedApiUsageFetcher,
+  RestrictedApiUsageFetcher,
 } from './src';

--- a/packages/core/usage-data/core-usage-data-server/src/core_usage_stats.ts
+++ b/packages/core/usage-data/core-usage-data-server/src/core_usage_stats.ts
@@ -159,3 +159,16 @@ export interface CoreDeprecatedApiUsageStats {
   apiTotalCalls: number;
   apiLastCalledAt: string;
 }
+
+/**
+ * @public
+ *
+ * CoreRestrictedApiUsageStats are collected over time while Kibana is running.
+ */
+export interface CoreRestrictedApiUsageStats {
+  apiId: string;
+  totalMarkedAsResolved: number;
+  markedAsResolvedLastCalledAt: string;
+  apiTotalCalls: number;
+  apiLastCalledAt: string;
+}

--- a/packages/core/usage-data/core-usage-data-server/src/index.ts
+++ b/packages/core/usage-data/core-usage-data-server/src/index.ts
@@ -12,12 +12,17 @@ export type {
   CoreEnvironmentUsageData,
   CoreConfigUsageData,
 } from './core_usage_data';
-export type { CoreUsageStats, CoreDeprecatedApiUsageStats } from './core_usage_stats';
+export type {
+  CoreUsageStats,
+  CoreDeprecatedApiUsageStats,
+  CoreRestrictedApiUsageStats,
+} from './core_usage_stats';
 export type {
   CoreUsageDataSetup,
   CoreUsageCounter,
   CoreIncrementUsageCounter,
   CoreIncrementCounterParams,
   DeprecatedApiUsageFetcher,
+  RestrictedApiUsageFetcher,
 } from './setup_contract';
 export type { CoreUsageData, ConfigUsageData, CoreUsageDataStart } from './start_contract';

--- a/packages/core/usage-data/core-usage-data-server/src/setup_contract.ts
+++ b/packages/core/usage-data/core-usage-data-server/src/setup_contract.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ISavedObjectsRepository } from '@kbn/core-saved-objects-api-server';
-import type { CoreDeprecatedApiUsageStats } from './core_usage_stats';
+import type { CoreDeprecatedApiUsageStats, CoreRestrictedApiUsageStats } from './core_usage_stats';
 
 /**
  * Internal API for registering the Usage Tracker used for Core's usage data payload.
@@ -22,6 +22,7 @@ export interface CoreUsageDataSetup {
    */
   registerUsageCounter: (usageCounter: CoreUsageCounter) => void;
   registerDeprecatedUsageFetch: (fetchFn: DeprecatedApiUsageFetcher) => void;
+  registerRestrictedUsageFetch: (fetchFn: RestrictedApiUsageFetcher) => void;
 }
 
 /**
@@ -58,3 +59,11 @@ export type CoreIncrementUsageCounter = (params: CoreIncrementCounterParams) => 
 export type DeprecatedApiUsageFetcher = (params: {
   soClient: ISavedObjectsRepository;
 }) => Promise<CoreDeprecatedApiUsageStats[]>;
+
+/**
+ * @public
+ * Registers the restricted API fetcher to be called to grab all the restricted API usage details.
+ */
+export type RestrictedApiUsageFetcher = (params: {
+  soClient: ISavedObjectsRepository;
+}) => Promise<CoreRestrictedApiUsageStats[]>;

--- a/src/plugins/kibana_usage_collection/server/collectors/core/fetch_restricted_api_counters.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/core/fetch_restricted_api_counters.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { CoreRestrictedApiUsageStats } from '@kbn/core-usage-data-server';
+import { USAGE_COUNTERS_SAVED_OBJECT_TYPE } from '@kbn/usage-collection-plugin/server';
+
+import { createCounterFetcher, type CounterEvent } from '../common/counters';
+
+const RESTRICTED_API_COUNTERS_FILTER = `${USAGE_COUNTERS_SAVED_OBJECT_TYPE}.attributes.counterType: restricted_api_call\\:*`;
+
+const mergeCounter = (counter: CounterEvent, acc?: CoreRestrictedApiUsageStats) => {
+  if (acc && acc?.apiId !== counter.counterName) {
+    throw new Error(
+      `Failed to merge mismatching counterNames: ${acc.apiId} with ${counter.counterName}`
+    );
+  }
+  const isMarkedCounter = counter.counterType.endsWith(':marked_as_resolved');
+
+  const finalCounter = {
+    apiId: counter.counterName,
+    apiTotalCalls: 0,
+    apiLastCalledAt: 'unknown',
+    totalMarkedAsResolved: 0,
+    markedAsResolvedLastCalledAt: 'unknown',
+    ...(acc || {}),
+  };
+
+  if (isMarkedCounter) {
+    return finalCounter;
+  }
+
+  const isResolvedCounter = counter.counterType.endsWith(':resolved');
+  const totalKey = isResolvedCounter ? 'totalMarkedAsResolved' : 'apiTotalCalls';
+  const lastUpdatedKey = isResolvedCounter ? 'markedAsResolvedLastCalledAt' : 'apiLastCalledAt';
+
+  const newPayload = {
+    [totalKey]: (finalCounter[totalKey] || 0) + counter.total,
+    [lastUpdatedKey]: counter.lastUpdatedAt,
+  };
+
+  return {
+    ...finalCounter,
+    ...newPayload,
+  };
+};
+
+function mergeCounters(counters: CounterEvent[]): CoreRestrictedApiUsageStats[] {
+  const mergedCounters = counters.reduce((acc, counter) => {
+    const { counterName } = counter;
+    const existingCounter = acc[counterName];
+
+    acc[counterName] = mergeCounter(counter, existingCounter);
+
+    return acc;
+  }, {} as Record<string, CoreRestrictedApiUsageStats>);
+
+  return Object.values(mergedCounters);
+}
+
+export const fetchRestrictedApiCounterStats = (logger: Logger) => {
+  return createCounterFetcher(logger, RESTRICTED_API_COUNTERS_FILTER, mergeCounters);
+};

--- a/src/plugins/kibana_usage_collection/server/collectors/core/index.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/core/index.ts
@@ -9,3 +9,4 @@
 
 export { registerCoreUsageCollector } from './core_usage_collector';
 export { fetchDeprecatedApiCounterStats } from './fetch_deprecated_api_counters';
+export { fetchRestrictedApiCounterStats } from './fetch_restricted_api_counters';

--- a/src/plugins/kibana_usage_collection/server/collectors/index.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/index.ts
@@ -17,7 +17,11 @@ export {
 export { registerOpsStatsCollector } from './ops_stats';
 export { registerCloudProviderUsageCollector } from './cloud';
 export { registerCspCollector } from './csp';
-export { registerCoreUsageCollector, fetchDeprecatedApiCounterStats } from './core';
+export {
+  registerCoreUsageCollector,
+  fetchDeprecatedApiCounterStats,
+  fetchRestrictedApiCounterStats,
+} from './core';
 export { registerLocalizationUsageCollector } from './localization';
 export { registerConfigUsageCollector } from './config_usage';
 export { registerUiCountersUsageCollector } from './ui_counters';

--- a/src/plugins/kibana_usage_collection/server/plugin.ts
+++ b/src/plugins/kibana_usage_collection/server/plugin.ts
@@ -44,6 +44,7 @@ import {
   registerSavedObjectsCountUsageCollector,
   registerEventLoopDelaysCollector,
   fetchDeprecatedApiCounterStats,
+  fetchRestrictedApiCounterStats,
 } from './collectors';
 
 interface KibanaUsageCollectionPluginsDepsSetup {
@@ -79,6 +80,10 @@ export class KibanaUsageCollectionPlugin implements Plugin {
       this.logger.get('deprecated-api-usage')
     );
     coreSetup.coreUsageData.registerDeprecatedUsageFetch(deprecatedUsageFetch);
+    const restrictedUsageFetch = fetchRestrictedApiCounterStats(
+      this.logger.get('restricted-api-usage')
+    );
+    coreSetup.coreUsageData.registerRestrictedUsageFetch(restrictedUsageFetch);
     this.registerUsageCollectors(
       usageCollection,
       coreSetup,

--- a/x-pack/plugins/upgrade_assistant/README.md
+++ b/x-pack/plugins/upgrade_assistant/README.md
@@ -316,6 +316,40 @@ GET .kibana_usage_counters/_search
 
 ```
 
+#### Kibana internal API access deprecation: // @Tina TODO: modify and update
+Run kibana locally with the test example plugin that has internal routes
+```
+yarn start --plugin-path=examples/routing_example --plugin-path=examples/developer_examples
+```
+
+The following internal routes examples are registered inside the folder: `examples/routing_example/server/routes/message_routes`
+//  /internal/get_message
+Run them in the console to trigger the access deprecation condition so they show up in the UA:
+
+```
+# Versioned routes: Version 1 is internal
+GET kbn:/api/routing_example/internal/get_message
+```
+
+1. You can also mark as deprecated in the UA to remove the route from the list.
+2. Check the telemetry response to see the reported data about the internal route.
+4. Internally you can see the access restriction counters from the dev console by running the following:
+```
+GET .kibana_usage_counters/_search
+{
+    "query": {
+        "bool": {
+            "should": [
+              {"match": { "usage-counter.counterType": "restricted_api_call:total"}},
+              {"match": { "usage-counter.counterType": "restricted_api_call:resolved"}},
+              {"match": { "usage-counter.counterType": "restricted_api_call:marked_as_resolved"}}
+            ]
+        }
+    }
+}
+
+```
+
 For a complete list of Kibana deprecations, refer to the [8.0 Kibana deprecations meta issue](https://github.com/elastic/kibana/issues/109166).
 
 ### Errors


### PR DESCRIPTION
## Summary

External access to internal Kibana APIs are blocked as of v9.0.0. This is a breaking change that we need to surface in UA.

Current branch is WIP for code sharing and pairing. 

