### PR TITLE
[UA] Removes logs explorer panel from UI

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecation_logs/es_deprecation_logs.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecation_logs/es_deprecation_logs.test.tsx
@@ -18,12 +18,7 @@ import {
   APPS_WITH_DEPRECATION_LOGS,
   DEPRECATION_LOGS_ORIGIN_FIELD,
 } from '../../../common/constants';
-import { stringifySearchParams } from '../helpers/app_context.mock';
 
-// Once the logs team register the kibana locators in their app, we should be able
-// to remove this mock and follow a similar approach to how discover link is tested.
-// See: https://github.com/elastic/kibana/issues/104855
-const MOCKED_TIME = '2021-09-05T10:49:01.805Z';
 jest.mock('../../../public/application/lib/logs_checkpoint', () => {
   const originalModule = jest.requireActual('../../../public/application/lib/logs_checkpoint');
 
@@ -155,40 +150,6 @@ describe('ES deprecation logs', () => {
   describe('Step 2 - Analyze logs', () => {
     beforeEach(async () => {
       httpRequestsMockHelpers.setLoadDeprecationLoggingResponse(getLoggingResponse(true));
-    });
-
-    test('Has a link to see logs in observability app', async () => {
-      await act(async () => {
-        testBed = await setupESDeprecationLogsPage(httpSetup, {
-          http: {
-            basePath: {
-              prepend: (url: string) => url,
-            },
-          },
-        });
-      });
-
-      const { component, exists, find } = testBed;
-
-      component.update();
-
-      expect(exists('viewObserveLogs')).toBe(true);
-      const locatorParams = stringifySearchParams({
-        id: DEPRECATION_LOGS_INDEX,
-        timeRange: {
-          from: MOCKED_TIME,
-          to: 'now',
-        },
-        query: {
-          language: 'kuery',
-          query: `not ${DEPRECATION_LOGS_ORIGIN_FIELD} : (${APPS_WITH_DEPRECATION_LOGS.join(
-            ' or '
-          )})`,
-        },
-      });
-      const href = find('viewObserveLogs').props().href;
-      expect(href).toContain('logsExplorerUrl');
-      expect(href).toContain(locatorParams);
     });
 
     test('Has a link to see logs in discover app', async () => {

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/external_links.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/external_links.tsx
@@ -10,23 +10,15 @@ import { buildPhrasesFilter, PhrasesFilter } from '@kbn/es-query';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { METRIC_TYPE } from '@kbn/analytics';
-import { EuiLink, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiPanel, EuiText } from '@elastic/eui';
+import { EuiLink, EuiSpacer, EuiPanel, EuiText } from '@elastic/eui';
 import { DataView } from '@kbn/data-views-plugin/common';
-import {
-  OBS_LOGS_EXPLORER_DATA_VIEW_LOCATOR_ID,
-  ObsLogsExplorerDataViewLocatorParams,
-} from '@kbn/deeplinks-observability';
 import {
   APPS_WITH_DEPRECATION_LOGS,
   DEPRECATION_LOGS_ORIGIN_FIELD,
 } from '../../../../../common/constants';
 import { DataPublicPluginStart } from '../../../../shared_imports';
 import { useAppContext } from '../../../app_context';
-import {
-  uiMetricService,
-  UIM_OBSERVABILITY_CLICK,
-  UIM_DISCOVER_CLICK,
-} from '../../../lib/ui_metric';
+import { uiMetricService, UIM_DISCOVER_CLICK } from '../../../lib/ui_metric';
 
 import { DEPRECATION_LOGS_INDEX_PATTERN } from '../../../../../common/constants';
 
@@ -129,48 +121,6 @@ const DiscoverAppLink: FunctionComponent<Props> = ({ checkpoint, deprecationData
   );
 };
 
-const ObservabilityAppLink: FunctionComponent<Props> = ({ checkpoint, deprecationDataView }) => {
-  const {
-    plugins: {
-      share: { url },
-    },
-  } = useAppContext();
-
-  const logsLocator = url.locators.get<ObsLogsExplorerDataViewLocatorParams>(
-    OBS_LOGS_EXPLORER_DATA_VIEW_LOCATOR_ID
-  )!;
-
-  if (!deprecationDataView.id) return null;
-
-  const logsUrl = logsLocator.getRedirectUrl({
-    id: deprecationDataView.id,
-    timeRange: {
-      from: checkpoint,
-      to: 'now',
-    },
-    query: {
-      language: 'kuery',
-      query: `not ${DEPRECATION_LOGS_ORIGIN_FIELD} : (${APPS_WITH_DEPRECATION_LOGS.join(' or ')})`,
-    },
-  });
-
-  return (
-    // eslint-disable-next-line @elastic/eui/href-or-on-click
-    <EuiLink
-      href={logsUrl}
-      onClick={() => {
-        uiMetricService.trackUiMetric(METRIC_TYPE.CLICK, UIM_OBSERVABILITY_CLICK);
-      }}
-      data-test-subj="viewObserveLogs"
-    >
-      <FormattedMessage
-        id="xpack.upgradeAssistant.overview.viewObservabilityResultsAction"
-        defaultMessage="View deprecation logs in Logs Explorer"
-      />
-    </EuiLink>
-  );
-};
-
 export const ExternalLinks: FunctionComponent<Omit<Props, 'deprecationDataView'>> = ({
   checkpoint,
 }) => {
@@ -190,42 +140,19 @@ export const ExternalLinks: FunctionComponent<Omit<Props, 'deprecationDataView'>
   }, [dataService, checkpoint, share.url.locators]);
 
   return (
-    <EuiFlexGroup>
-      <EuiFlexItem>
-        <EuiPanel>
-          <EuiText size="s">
-            <p>
-              <FormattedMessage
-                id="xpack.upgradeAssistant.overview.observe.observabilityDescription"
-                defaultMessage="Get insight into which deprecated APIs are being used and what applications you need to update."
-              />
-            </p>
-          </EuiText>
-          <EuiSpacer size="m" />
-          {deprecationDataView ? (
-            <ObservabilityAppLink
-              checkpoint={checkpoint}
-              deprecationDataView={deprecationDataView}
-            />
-          ) : null}
-        </EuiPanel>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiPanel>
-          <EuiText size="s">
-            <p>
-              <FormattedMessage
-                id="xpack.upgradeAssistant.overview.observe.discoveryDescription"
-                defaultMessage="Search and filter the deprecation logs to understand the types of changes you need to make."
-              />
-            </p>
-          </EuiText>
-          <EuiSpacer size="m" />
-          {deprecationDataView ? (
-            <DiscoverAppLink checkpoint={checkpoint} deprecationDataView={deprecationDataView} />
-          ) : null}
-        </EuiPanel>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <EuiPanel grow={false}>
+      <EuiText size="s">
+        <p>
+          <FormattedMessage
+            id="xpack.upgradeAssistant.overview.observe.discoveryDescription"
+            defaultMessage="Search and filter the deprecation logs to understand the types of changes you need to make."
+          />
+        </p>
+      </EuiText>
+      <EuiSpacer size="m" />
+      {deprecationDataView ? (
+        <DiscoverAppLink checkpoint={checkpoint} deprecationDataView={deprecationDataView} />
+      ) : null}
+    </EuiPanel>
   );
 };


### PR DESCRIPTION
## Summary
fix https://github.com/elastic/kibana/issues/201532
Removes panel that links to logs explorer.

## UI before
![Screenshot 2024-12-09 at 10 44 20](https://github.com/user-attachments/assets/a289039f-9335-4012-9f51-41581cea6ace)

## UI after
![Screenshot 2024-12-09 at 10 36 03](https://github.com/user-attachments/assets/39a3c3a4-40d1-4884-bdfb-a74c1d75d5d4)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.


