### PR TITLE
docs: add Cursor Cloud dev environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,16 @@ Follow existing patterns in the target area first; below are common defaults.
 - Make focused changes; avoid unrelated refactors.
 - Update docs and tests when behavior or usage changes.
 - Never remove, skip, or comment out tests to make them pass; fix the underlying code.
+
+## Cursor Cloud specific instructions
+Kibana requires Node `24.18.0` (see `.nvmrc`). The VM has an `/exec-daemon/node` (Node 22) shim that shadows `nvm` in `PATH`, so the startup update script and `~/.bashrc` prepend the nvm Node 24 bin dir. In new interactive shells `node -v` should already be `v24.18.0`; if it isn't, run `export PATH="$NVM_DIR/versions/node/v24.18.0/bin:$PATH"` before any `yarn`/`node scripts/*` command (otherwise tooling silently runs under Node 22).
+
+Running the stack (two long-lived services, best in separate tmux sessions):
+- Elasticsearch: `yarn es snapshot --license trial -E discovery.type=single-node` (listens on `:9200`, creds `elastic` / `changeme`).
+- Kibana dev server: `NODE_OPTIONS="--max-old-space-size=8192" yarn start --no-base-path` (listens on `:5601`, same creds). Start ES first. First boot builds ~222 optimizer bundles and takes several minutes.
+- The larger `NODE_OPTIONS` heap is required: without it the optimizer worker OOMs (V8 ~4GB default) while building big bundles like `lens`/`securitySolution`.
+
+Non-obvious gotcha — "Elastic did not load properly" after a crash: if a `yarn start` is interrupted (e.g. optimizer OOM), a bundle's output dir under `<module>/target/public/` can be left with a stale `.kbn-optimizer-cache` but no `*.js`. On restart the optimizer trusts the cache and skips rebuilding, so the browser fails to load that bundle. Fix: stop Kibana, delete the incomplete dirs, and restart. Find them with:
+`for d in $(find . -path "*target/public" -type d); do [ -f "$d/.kbn-optimizer-cache" ] && [ -z "$(ls "$d"/*.js 2>/dev/null)" ] && echo "$d"; done`
+
+Standard lint/test/type-check commands live in the sections above (`node scripts/jest`, `node scripts/eslint`, `node scripts/type_check --project ...`) — always scope them to a single package/config.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Kibana development environment for Cursor Cloud agents, and documents the non-obvious caveats discovered during setup in `AGENTS.md`.

The only code change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code was modified.

## What was verified

- **Bootstrap**: `yarn kbn bootstrap` (Node `24.18.0` via nvm, yarn `1.22.21`).
- **Elasticsearch**: `yarn es snapshot --license trial -E discovery.type=single-node` — cluster GREEN on `:9200`.
- **Kibana dev server**: `NODE_OPTIONS="--max-old-space-size=8192" yarn start --no-base-path` — `overall: available` on `:5601` (v9.6.0).
- **Lint**: `node scripts/eslint` — no errors.
- **Type check**: `node scripts/type_check --project ...` — exit 0.
- **Unit tests**: `node scripts/jest` — 6/6 passed.

## Hello-world task

Indexed a document into Elasticsearch, created a Kibana **data view** over it via the API, and confirmed it renders in the Data Views management UI after logging in:

[Kibana Data Views showing the created Hello Kibana DV](https://cursor.com/agents/bc-7c7463e8-e70d-4c75-9ec2-9d00c1c3f684/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkibana_dataviews.png)

## Key notes captured in AGENTS.md

- An `/exec-daemon/node` (Node 22) shim shadows nvm in `PATH`; Node 24 must be prepended.
- The optimizer needs a larger `NODE_OPTIONS` heap to avoid OOM on large bundles (`lens`, `securitySolution`).
- Recovery for the "Elastic did not load properly" error caused by a stale `.kbn-optimizer-cache` after an interrupted start.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c7463e8-e70d-4c75-9ec2-9d00c1c3f684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c7463e8-e70d-4c75-9ec2-9d00c1c3f684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

