### PR TITLE
Replace leftover beta API stability with experimental

### DIFF
--- a/docs/extend/contributing/api-design/guidelines-for-http-api-design-in-kibana.md
+++ b/docs/extend/contributing/api-design/guidelines-for-http-api-design-in-kibana.md
@@ -649,7 +649,7 @@ Every public API should have a release tag specified at the top of its documenta
 | -----| ------------| ------------- | ------------ |
 | Undocumented | Every public API should be documented, but if it isn't, we make no guarantees about it. These need to be eliminated and should become internal or documented. | | |
 | Experimental | A public API that may break or be removed at any time. | experimental[] | |
-| Beta | A public API that we make a best effort not to break or remove. However, there are no guarantees. | beta[] | |
+| Technical Preview | A public API that is under active development and may change before GA. | | |
 | Stable | No breaking changes outside of a Major | stable[] | |
 | Deprecated | Do not use, will be removed. | deprecated[] | |
 

--- a/docs/extend/tutorials/generating-oas-for-http-apis.md
+++ b/docs/extend/tutorials/generating-oas-for-http-apis.md
@@ -135,7 +135,7 @@ function registerFooRoute(router: IRouter, docLinks: DoclinksStart) {
         tags: ['oas-tag:my tag'],  // Each operation must have a tag that's used to group similar endpoints in the docs
         availability: {
           since: '1.0.0', // The version that the API was added.
-          stability: 'experimental', // The current lifecycle: experimental, beta, or stable
+          stability: 'experimental', // The current lifecycle: experimental, tech_preview, or stable
         },
       },
     })

--- a/src/platform/packages/shared/kbn-workflows/scripts/generate_es_connectors/generate_es_connectors.ts
+++ b/src/platform/packages/shared/kbn-workflows/scripts/generate_es_connectors/generate_es_connectors.ts
@@ -328,7 +328,7 @@ function generateMethodsAndPatterns(endpoint: SpecificationTypes.Endpoint): {
 }
 
 const SPEC_STABILITY_MAP: Partial<Record<SpecificationTypes.Stability, StabilityLevel>> = {
-  beta: 'beta',
+  beta: 'experimental',
   experimental: 'tech_preview',
 };
 

--- a/src/platform/packages/shared/kbn-workflows/scripts/shared/generate_contract_block.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/scripts/shared/generate_contract_block.test.ts
@@ -19,7 +19,7 @@ const baseContract: ContractMeta = {
   methods: ['GET', 'POST'],
   patterns: ['/_search', '/{index}/_search'],
   documentation: 'https://elastic.co/docs/search',
-  stability: 'beta',
+  stability: 'experimental',
   parameterTypes: {
     headerParams: [],
     pathParams: ['index'],
@@ -45,7 +45,7 @@ describe('escapeString', () => {
 describe('generateContractBlock', () => {
   it('should include all fields when optional fields are present', () => {
     const result = generateContractBlock(baseContract);
-    expect(result).toContain("stability: 'beta'");
+    expect(result).toContain("stability: 'experimental'");
     expect(result).toContain('`Search API`');
     expect(result).toContain('`Runs a search query`');
     expect(result).toContain("'https://elastic.co/docs/search'");

--- a/src/platform/packages/shared/kbn-workflows/scripts/shared/get_stability_from_x_state.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/scripts/shared/get_stability_from_x_state.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { OpenAPIV3 } from 'openapi-types';
+import { getStabilityFromXState } from './get_stability_from_x_state';
+
+const operationWithXState = (xState: string): OpenAPIV3.OperationObject =>
+  ({
+    responses: {},
+    'x-state': xState,
+  } as OpenAPIV3.OperationObject);
+
+describe('getStabilityFromXState', () => {
+  it('maps Technical Preview to tech_preview', () => {
+    expect(getStabilityFromXState(operationWithXState('Technical Preview'))).toBe('tech_preview');
+  });
+
+  it('maps Experimental to experimental', () => {
+    expect(getStabilityFromXState(operationWithXState('Experimental'))).toBe('experimental');
+  });
+
+  it('maps legacy Beta x-state to experimental', () => {
+    expect(getStabilityFromXState(operationWithXState('Beta'))).toBe('experimental');
+  });
+
+  it('returns undefined when x-state is missing', () => {
+    expect(getStabilityFromXState({ responses: {} })).toBeUndefined();
+  });
+});

--- a/src/platform/packages/shared/kbn-workflows/scripts/shared/get_stability_from_x_state.ts
+++ b/src/platform/packages/shared/kbn-workflows/scripts/shared/get_stability_from_x_state.ts
@@ -21,8 +21,8 @@ export function getStabilityFromXState(
   if (lower.startsWith('technical preview')) {
     return 'tech_preview';
   }
-  if (lower.startsWith('beta')) {
-    return 'beta';
+  if (lower.startsWith('experimental') || lower.startsWith('beta')) {
+    return 'experimental';
   }
   return undefined;
 }

--- a/src/platform/packages/shared/kbn-workflows/spec/step_definition_types.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/step_definition_types.ts
@@ -112,7 +112,7 @@ export interface BaseStepDefinition<
   documentation?: StepDocumentation;
 
   /**
-   * API stability level for this step (e.g. 'tech_preview', 'beta', 'stable').
+   * API stability level for this step (e.g. 'tech_preview', 'experimental', 'stable').
    * Built-in steps: omit means stable (no badge). Extension-registered steps: omit
    * defaults to tech_preview in the UI; set 'stable' explicitly to graduate.
    */

--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -588,7 +588,7 @@ export type CompletionFn = () => Promise<
   Array<{ label: string; value: string; detail?: string; documentation?: string }>
 >;
 
-export type StabilityLevel = 'stable' | 'beta' | 'tech_preview';
+export type StabilityLevel = 'stable' | 'experimental' | 'tech_preview';
 
 export interface BaseConnectorContract {
   type: string;

--- a/src/platform/plugins/shared/workflows_extensions/.claude/skills/workflows-custom-triggers/SKILL.md
+++ b/src/platform/plugins/shared/workflows_extensions/.claude/skills/workflows-custom-triggers/SKILL.md
@@ -31,7 +31,7 @@ A custom workflow trigger is owned and registered by a **plugin other than `work
 
 A trigger lives in three layers:
 
-- **Common** — `id`, `eventSchema`, `title`, `description`, `stability`, optional `documentation` / `snippets`. Imported by both server and public to keep them in sync. Set `stability` to `'tech_preview'`, `'beta'`, or `'stable'` based on the trigger's maturity.
+- **Common** — `id`, `eventSchema`, `title`, `description`, `stability`, optional `documentation` / `snippets`. Imported by both server and public to keep them in sync. Set `stability` to `'tech_preview'`, `'experimental'`, or `'stable'` based on the trigger's maturity.
 - **Server** — registers the **same** common definition via `registerTriggerDefinition`; emits events with `emitEvent`.
 - **Public** — spreads the common definition and adds **icon** only (browser-only UI).
 

--- a/src/platform/plugins/shared/workflows_extensions/common/trigger_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/trigger_registry/types.ts
@@ -72,7 +72,7 @@ export interface CommonTriggerDefinition<EventSchema extends z.ZodType = z.ZodTy
    */
   snippets?: TriggerSnippets;
   /**
-   * API stability level for this trigger (e.g. 'tech_preview', 'beta', 'stable').
+   * API stability level for this trigger (e.g. 'tech_preview', 'experimental', 'stable').
    * Required so every trigger explicitly declares its contract. Set 'stable' for GA triggers (no badge).
    */
   stability: StabilityLevel;

--- a/src/platform/plugins/shared/workflows_extensions/dev_docs/TRIGGERS.md
+++ b/src/platform/plugins/shared/workflows_extensions/dev_docs/TRIGGERS.md
@@ -60,7 +60,7 @@ export const commonMyTriggerDefinition: CommonTriggerDefinition = {
 };
 ```
 
-- Set `stability` (required) to `'tech_preview'`, `'beta'`, or `'stable'` based on the trigger's maturity. Use `'stable'` for GA triggers (no badge in the editor).
+- Set `stability` (required) to `'tech_preview'`, `'experimental'`, or `'stable'` based on the trigger's maturity. Use `'stable'` for GA triggers (no badge in the editor).
 - Use `.describe()` on schema fields so the UI and docs show helpful text.
 - `eventSchema` must be a Zod object schema; payloads are validated at emit time.
 - When you provide `documentation.examples`, each example must only reference fields present on `eventSchema` (agents pattern-match YAML examples).

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/ui/actions_menu.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/ui/actions_menu.tsx
@@ -176,10 +176,10 @@ export function ActionsMenu({
                     css={styles.techPreviewBadge}
                   />
                 )}
-                {action.stability === 'beta' && (
+                {action.stability === 'experimental' && (
                   <EuiBetaBadge
-                    label={i18n.translate('workflows.actionsMenu.betaBadge', {
-                      defaultMessage: 'Beta',
+                    label={i18n.translate('workflows.actionsMenu.experimentalBadge', {
+                      defaultMessage: 'Experimental',
                     })}
                     size="s"
                     css={styles.techPreviewBadge}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/base_monaco_connector_handler.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/base_monaco_connector_handler.test.ts
@@ -66,7 +66,7 @@ class TestHandler extends BaseMonacoConnectorHandler {
   }
 
   public exposedPrependStabilityBadgeToContent(
-    stability: 'tech_preview' | 'beta' | 'stable' | undefined,
+    stability: 'tech_preview' | 'experimental' | 'stable' | undefined,
     bodyLines: string[]
   ): string {
     return this.prependStabilityBadgeToContent(stability, bodyLines);
@@ -309,11 +309,13 @@ describe('BaseMonacoConnectorHandler', () => {
       );
     });
 
-    it('should return beta stability from cached connectors', () => {
+    it('should return experimental stability from cached connectors', () => {
       (getCachedAllConnectors as jest.Mock).mockReturnValue([
-        { type: 'elasticsearch.search', stability: 'beta' },
+        { type: 'elasticsearch.search', stability: 'experimental' },
       ]);
-      expect(handler.exposedGetConnectorStabilityFromCache('elasticsearch.search')).toBe('beta');
+      expect(handler.exposedGetConnectorStabilityFromCache('elasticsearch.search')).toBe(
+        'experimental'
+      );
     });
 
     it('should return stability from connectors map when static list is empty', () => {
@@ -330,7 +332,7 @@ describe('BaseMonacoConnectorHandler', () => {
 
     it('should prefer connectors map stability over static list', () => {
       (getCachedAllConnectors as jest.Mock).mockReturnValue([
-        { type: 'slack.postMessage', stability: 'beta' },
+        { type: 'slack.postMessage', stability: 'experimental' },
       ]);
       (getCachedAllConnectorsMap as jest.Mock).mockReturnValue(
         new Map([['slack.postMessage', { type: 'slack.postMessage', stability: 'tech_preview' }]])

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/base_monaco_connector_handler.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/base_monaco_connector_handler.ts
@@ -161,7 +161,7 @@ export abstract class BaseMonacoConnectorHandler implements MonacoConnectorHandl
     const mapStability = getCachedAllConnectorsMap()?.get(connectorType)?.stability;
     const listStability = getCachedAllConnectors().find((c) => c.type === connectorType)?.stability;
     const stability = mapStability ?? listStability;
-    if (stability === 'tech_preview' || stability === 'beta') {
+    if (stability === 'tech_preview' || stability === 'experimental') {
       return stability;
     }
     return undefined;

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/elasticsearch_connector_handler.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/elasticsearch_connector_handler.test.ts
@@ -53,7 +53,7 @@ describe('ElasticsearchMonacoConnectorHandler', () => {
         type: 'elasticsearch.index',
         description: 'Index a document',
         documentation: 'https://elastic.co/guide/en/{branch}/index-api.html',
-        stability: 'beta',
+        stability: 'experimental',
         methods: ['PUT'],
         patterns: ['/{index}/_doc/{id}'],
       },
@@ -145,7 +145,7 @@ describe('ElasticsearchMonacoConnectorHandler', () => {
       expect(result).toBeNull();
     });
 
-    it('should include stability note for beta connectors', async () => {
+    it('should include stability note for experimental connectors', async () => {
       buildElasticsearchRequest.mockReturnValue({
         method: 'PUT',
         path: '/my-index/_doc/1',
@@ -162,7 +162,7 @@ describe('ElasticsearchMonacoConnectorHandler', () => {
       const result = await handler.generateHoverContent(context);
 
       expect(result).not.toBeNull();
-      expect(result?.value).toContain('Beta');
+      expect(result?.value).toContain('Experimental');
       expect(result?.value.indexOf('<img src="data:image/svg+xml,')).toBeLessThan(
         result!.value.indexOf('**Endpoint**')
       );

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/workflow_execute_handler.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/workflow_execute_handler.test.ts
@@ -125,7 +125,7 @@ describe('WorkflowExecuteMonacoConnectorHandler', () => {
 
       expect(result).not.toBeNull();
       expect(result?.value).not.toContain('Technical Preview');
-      expect(result?.value).not.toContain('Beta');
+      expect(result?.value).not.toContain('Experimental');
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/stability/get_extension_stability.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/stability/get_extension_stability.test.ts
@@ -11,9 +11,9 @@ import type { StabilitySource } from './get_extension_stability';
 import { getExtensionStability } from './get_extension_stability';
 
 describe('getExtensionStability', () => {
-  it('returns explicit beta stability', () => {
-    const definition: StabilitySource = { stability: 'beta' };
-    expect(getExtensionStability(definition)).toBe('beta');
+  it('returns explicit experimental stability', () => {
+    const definition: StabilitySource = { stability: 'experimental' };
+    expect(getExtensionStability(definition)).toBe('experimental');
   });
 
   it('returns undefined for stable extension definitions', () => {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/stability/get_extension_stability.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/stability/get_extension_stability.ts
@@ -17,7 +17,7 @@ export interface StabilitySource {
  * Stability level for extension-registered steps and triggers (hover badge + suggest parity for tech preview).
  */
 export function getExtensionStability(definition: StabilitySource): StabilityLevel | undefined {
-  if (definition.stability === 'beta' || definition.stability === 'tech_preview') {
+  if (definition.stability === 'experimental' || definition.stability === 'tech_preview') {
     return definition.stability;
   }
   if (definition.stability === 'stable') {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/stability/get_stability_badge_html.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/stability/get_stability_badge_html.test.ts
@@ -25,9 +25,9 @@ describe('getStabilityBadgeHtml', () => {
     expect(html).toContain('Tech preview');
   });
 
-  it('returns beta badge markup', () => {
-    const html = getStabilityBadgeHtml('beta');
-    expect(html).toContain('Beta');
+  it('returns experimental badge markup', () => {
+    const html = getStabilityBadgeHtml('experimental');
+    expect(html).toContain('Experimental');
   });
 
   it('returns empty string for stable stability without requiring theme', () => {
@@ -63,7 +63,7 @@ describe('buildStabilityBadgeHtml', () => {
   });
 
   it('allocates wider badges for long labels', () => {
-    const short = buildStabilityBadgeHtml('Beta', { fill: '#fff', stroke: '#000', text: '#111' });
+    const short = buildStabilityBadgeHtml('Exp', { fill: '#fff', stroke: '#000', text: '#111' });
     const long = buildStabilityBadgeHtml('A very long experimental label', {
       fill: '#fff',
       stroke: '#000',

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/stability/get_stability_badge_html.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/stability/get_stability_badge_html.ts
@@ -67,9 +67,9 @@ export function getStabilityBadgeHtml(stability: StabilityLevel | undefined): st
     });
     return buildStabilityBadgeHtml(label, getStabilityBadgeColors());
   }
-  if (stability === 'beta') {
-    const label = i18n.translate('workflows.actionsMenu.betaBadge', {
-      defaultMessage: 'Beta',
+  if (stability === 'experimental') {
+    const label = i18n.translate('workflows.actionsMenu.experimentalBadge', {
+      defaultMessage: 'Experimental',
     });
     return buildStabilityBadgeHtml(label, getStabilityBadgeColors());
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #274670: `beta` was removed from Kibana HTTP route availability when Technical Preview was formalized, but `@kbn/workflows` still had `StabilityLevel = 'stable' | 'beta' | 'tech_preview'`.

This replaces workflows `beta` with `experimental` end-to-end (type, x-state/ES generator mappings, UI badges, tests) and cleans up stale API availability docs that still listed Beta.

## Changes

- `StabilityLevel`: `'beta'` → `'experimental'`
- `getStabilityFromXState`: map `Experimental` and legacy `Beta` → `'experimental'`
- ES connector `SPEC_STABILITY_MAP`: `beta` → `'experimental'`
- Workflows UI badges/filters show **Experimental** instead of Beta
- Docs: API design release tags + OAS tutorial + workflows trigger docs/skills

## Test plan

- [x] Jest: `get_stability_from_x_state`, `generate_contract_block`, stability badge/extension helpers, monaco connector handlers
- [ ] eslint on changed files
- [ ] Confirm no remaining workflows `stability: 'beta'` usages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b574e73f-288f-4936-9d3b-7b70987a5df6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b574e73f-288f-4936-9d3b-7b70987a5df6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

