### PR TITLE
docs(agents): add Cursor Cloud dev stack run notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,17 @@ Follow existing patterns in the target area first; below are common defaults.
 - Make focused changes; avoid unrelated refactors.
 - Update docs and tests when behavior or usage changes.
 - Never remove, skip, or comment out tests to make them pass; fix the underlying code.
+
+## Cursor Cloud specific instructions
+Dependencies are refreshed automatically on startup via `yarn kbn bootstrap` (the configured update script). Node/yarn versions are already correct. The notes below are the non-obvious bits for running the stack.
+
+### Running the dev stack (Elasticsearch + Kibana)
+Both are long-running foreground processes — run each in its own tmux session, not as one-shot background jobs.
+- Elasticsearch: `yarn es snapshot` — downloads a nightly ES snapshot into `.es/` (only the first run downloads; subsequent runs reuse it), then serves on `http://localhost:9200` with `elastic:changeme` (trial license, security + SAML mock realm enabled). Wait for the `kbn/es setup complete` / cluster `GREEN` line. The `vm.max_map_count [65530] is too low` bootstrap warning is harmless here.
+- Kibana: `yarn start` (after ES is up). First start compiles ~226 optimizer bundles (a few minutes) before the server is usable. Ready when the log prints `Kibana is now available`.
+
+### Non-obvious gotchas
+- Kibana dev serves under a **random basepath** (e.g. `http://localhost:5601/bxz`), printed in the logs as `http server running at ...`. Bare `http://localhost:5601/` will not work — always use the basepath from the log.
+- Dev is auto-configured with the **SAML Mock IdP**, so the default login page is SAML. For scripted/basic login use `http://localhost:5601/<basepath>/login?auth_provider_hint=cloud-basic` and log in as `elastic` / `changeme`.
+- REST calls to Kibana work with basic auth `elastic:changeme`; POST/PUT/DELETE require the `kbn-xsrf: true` header (e.g. `curl -u elastic:changeme -H 'kbn-xsrf: true' ...`). ES is reachable directly at `:9200` with the same credentials.
+- Playwright browsers are already installed under `~/.cache/ms-playwright`; launch chromium with `--no-sandbox` in this VM.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up the Kibana development environment in the Cursor Cloud VM, ran the full stack (Elasticsearch + Kibana in dev mode), and verified lint/test/run all work. The only code change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md` capturing the non-obvious startup caveats (random dev basepath, SAML Mock IdP / basic-auth login, `kbn-xsrf` header, long optimizer build).

The startup dependency refresh is handled by the update script `yarn kbn bootstrap` (no repo change needed for that).

## What was verified

| Step | Command | Result |
|------|---------|--------|
| Bootstrap | `yarn kbn bootstrap` | success |
| Elasticsearch | `yarn es snapshot` | cluster GREEN on `:9200` |
| Kibana (dev) | `yarn start` | `Kibana is now available` on `http://localhost:5601/<basepath>` |
| Lint | `node scripts/eslint <file>` | no errors |
| Unit test | `node scripts/jest src/core/packages/http/server-internal/src/http_server.test.ts` | 91 passed |

## Hello-world (end-to-end)

Created an ES index + document, created a Kibana **data view** (a persisted saved object) via the Kibana API, and confirmed it renders in the running UI under Stack Management → Data Views ("Hello Kibana DV").

### Authenticated Kibana home
[Kibana home](https://cursor.com/agents/bc-d51ab8a1-9a46-4004-aa4d-2c422a419b20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkbn%2F02-home.png)

### Data view created via API, shown in the UI
[Data Views](https://cursor.com/agents/bc-d51ab8a1-9a46-4004-aa4d-2c422a419b20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkbn%2F03-data-views.png)

### Demo video (login → home → data views → discover)
[demo.webm](https://cursor.com/agents/bc-d51ab8a1-9a46-4004-aa4d-2c422a419b20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkbn%2Fdemo.webm)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d51ab8a1-9a46-4004-aa4d-2c422a419b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d51ab8a1-9a46-4004-aa4d-2c422a419b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

