### PR TITLE
[OAS] Collapse zod `.nullable()` into `nullable: true`

### DIFF
--- a/packages/kbn-api-contracts/allowlist.json
+++ b/packages/kbn-api-contracts/allowlist.json
@@ -175,6 +175,34 @@
       "reason": "OAS accuracy fix: schema.any() now correctly preserves nullable in OAS output. Response property attributes became nullable for status 400. No runtime behavior change.",
       "approvedBy": "@elastic/fleet",
       "prUrl": "https://github.com/elastic/kibana/pull/264235"
+    },
+    {
+      "path": "/api/fleet/epm/packages/_bulk",
+      "method": "post",
+      "reason": "OAS accuracy fix: the Zod converter now collapses .nullable() to `nullable: true` instead of leaving a half-converted `anyOf: [T, { nullable: true }]` wrapper. Same set of accepted values, canonical OAS 3.0 spelling. No runtime behavior change.",
+      "approvedBy": "@elastic/fleet",
+      "oasdiffId": "response-property-became-nullable"
+    },
+    {
+      "path": "/api/security/entity_store/entities/{entityType}",
+      "method": "post",
+      "reason": "OAS accuracy fix: the Zod converter now collapses .nullable() to `nullable: true` instead of leaving a half-converted `anyOf: [T, { nullable: true }]` wrapper. Same set of accepted values, canonical OAS 3.0 spelling. No runtime behavior change.",
+      "approvedBy": "@elastic/security-entity-analytics",
+      "oasdiffId": "request-body-any-of-removed"
+    },
+    {
+      "path": "/api/security/entity_store/entities/{entityType}",
+      "method": "put",
+      "reason": "OAS accuracy fix: the Zod converter now collapses .nullable() to `nullable: true` instead of leaving a half-converted `anyOf: [T, { nullable: true }]` wrapper. Same set of accepted values, canonical OAS 3.0 spelling. No runtime behavior change.",
+      "approvedBy": "@elastic/security-entity-analytics",
+      "oasdiffId": "request-body-any-of-removed"
+    },
+    {
+      "path": "/api/security/entity_store/entities/bulk",
+      "method": "put",
+      "reason": "OAS accuracy fix: the Zod converter now collapses .nullable() to `nullable: true` instead of leaving a half-converted `anyOf: [T, { nullable: true }]` wrapper. Same set of accepted values, canonical OAS 3.0 spelling. No runtime behavior change.",
+      "approvedBy": "@elastic/security-entity-analytics",
+      "oasdiffId": "request-property-any-of-removed"
     }
   ]
 }

--- a/src/platform/packages/private/kbn-validate-oas/redocly_compatibility_linter/compatibility_rules_plugin.js
+++ b/src/platform/packages/private/kbn-validate-oas/redocly_compatibility_linter/compatibility_rules_plugin.js
@@ -32,17 +32,25 @@ const isPathParameter = (value) => {
 };
 
 /**
+ * A null branch that survived conversion instead of being folded into its
+ * parent as `nullable: true`. Two spellings reach here: `{ enum: [], nullable:
+ * true }` from the @kbn/config-schema converter, and a bare `{ nullable: true }`
+ * from the Zod converter. Both carry no type and constrain nothing, so a
+ * generator sees them as an untyped union member.
+ *
  * @param {unknown} value
- * @returns {value is SchemaLike & { enum: []; nullable: true; type?: undefined }}
+ * @returns {value is SchemaLike & { nullable: true; type?: undefined }}
  */
 const isNullablePlaceholder = (value) => {
-  return (
-    isPlainObject(value) &&
-    Array.isArray(value.enum) &&
-    value.enum.length === 0 &&
-    value.nullable === true &&
-    value.type === undefined
-  );
+  if (!isPlainObject(value) || value.nullable !== true || value.type !== undefined) {
+    return false;
+  }
+
+  if (Array.isArray(value.enum)) {
+    return value.enum.length === 0;
+  }
+
+  return Object.keys(value).length === 1;
 };
 
 /**
@@ -86,7 +94,7 @@ function NoEmptyNullableEnum() {
 
         ctx.report({
           message:
-            'Found the internal `enum: []` + `nullable: true` placeholder. Null values must be emitted as an OpenAPI-compatible schema.',
+            'Found an internal nullable placeholder (`enum: []` + `nullable: true`, or a bare `nullable: true` branch). Null values must be emitted as an OpenAPI-compatible schema.',
           location: ctx.location,
         });
       },

--- a/src/platform/packages/private/kbn-validate-oas/redocly_compatibility_linter/compatibility_rules_plugin.test.js
+++ b/src/platform/packages/private/kbn-validate-oas/redocly_compatibility_linter/compatibility_rules_plugin.test.js
@@ -41,4 +41,17 @@ describe('compatibility rules plugin predicates', () => {
       })
     ).toBe(false);
   });
+
+  it('identifies the bare `nullable: true` branch left by the Zod converter', () => {
+    expect(compatibilityRulesPlugin._test.isNullablePlaceholder({ nullable: true })).toBe(true);
+    expect(
+      compatibilityRulesPlugin._test.isNullablePlaceholder({ nullable: true, type: 'string' })
+    ).toBe(false);
+    expect(
+      compatibilityRulesPlugin._test.isNullablePlaceholder({
+        nullable: true,
+        description: 'a described nullable branch still constrains nothing on its own',
+      })
+    ).toBe(false);
+  });
 });

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.test.ts
@@ -112,6 +112,114 @@ describe('zod', () => {
       });
     });
 
+    describe('.nullable()', () => {
+      test('collapses a nullable scalar into nullable: true', () => {
+        const result = convert(
+          z.object({ createdBy: z.string().nullable().describe('Who created it.') }) as any
+        );
+
+        expect(result.schema).toMatchObject({
+          properties: {
+            createdBy: { type: 'string', nullable: true, description: 'Who created it.' },
+          },
+        });
+        expect(result.schema.properties!.createdBy).not.toHaveProperty('anyOf');
+      });
+
+      test('collapses .nullish() the same way', () => {
+        const result = convert(z.object({ count: z.number().nullish() }) as any);
+
+        expect(result.schema).toMatchObject({
+          properties: { count: { type: 'number', nullable: true } },
+        });
+      });
+
+      test('keeps the combiner and marks it nullable when several branches remain', () => {
+        const result = convert(
+          z.object({ value: z.union([z.string(), z.number(), z.boolean()]).nullable() }) as any
+        );
+
+        expect(result.schema).toMatchObject({
+          properties: {
+            value: {
+              nullable: true,
+              anyOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }],
+            },
+          },
+        });
+      });
+
+      test('collapses a nullable enum', () => {
+        const result = convert(
+          z.object({ criticality: z.enum(['low', 'high']).nullable() }) as any
+        );
+
+        expect(result.schema).toMatchObject({
+          properties: { criticality: { type: 'string', enum: ['low', 'high'], nullable: true } },
+        });
+      });
+
+      test('collapses a nullable inside a nullable object', () => {
+        const result = convert(
+          z.object({
+            throttle: z.object({ interval: z.string().nullable() }).nullable(),
+          }) as any
+        );
+
+        expect(result.schema).toMatchObject({
+          properties: {
+            throttle: {
+              type: 'object',
+              nullable: true,
+              properties: { interval: { type: 'string', nullable: true } },
+            },
+          },
+        });
+      });
+
+      test('boxes a nullable named component in allOf so nullable is not a $ref sibling', () => {
+        const groupingMode = z.enum(['per_episode', 'per_alert']);
+        registerZodV4Component(groupingMode, 'GroupingMode');
+
+        const result = convert(z.object({ groupingMode: groupingMode.nullable() }) as any);
+
+        expect(result.shared).toHaveProperty('GroupingMode');
+        expect(result.shared.GroupingMode).not.toHaveProperty('nullable');
+        expect(result.schema.properties!.groupingMode).toEqual({
+          allOf: [{ $ref: '#/components/schemas/GroupingMode' }],
+          nullable: true,
+        });
+      });
+
+      test('boxes a nullable recursive $ref in allOf', () => {
+        const condition: z.ZodType = z.lazy(() =>
+          z.object({ field: z.string(), and: z.array(condition).optional() })
+        );
+        registerZodV4Component(condition, 'Condition');
+
+        const result = convert(z.object({ condition: condition.nullable() }) as any);
+
+        expect(result.shared).toHaveProperty('Condition');
+        expect(result.shared.Condition).not.toHaveProperty('nullable');
+        expect(result.schema.properties!.condition).toEqual({
+          allOf: [{ $ref: '#/components/schemas/Condition' }],
+          nullable: true,
+        });
+      });
+
+      test('leaves no half-converted { nullable: true } branch behind', () => {
+        const result = convert(
+          z.object({
+            a: z.string().nullable(),
+            b: z.array(z.string()).nullable(),
+            c: z.object({ d: z.number().nullable() }).nullable(),
+          }) as any
+        );
+
+        expect(JSON.stringify(result)).not.toContain('{"nullable":true}');
+      });
+    });
+
     test('convert handles DeepStrict-wrapped body schema', () => {
       const bodySchema = z.object({
         name: z.string(),

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.ts
@@ -701,6 +701,72 @@ function mergeInlineOasExtensions(node: unknown): unknown {
   return result;
 }
 
+/** A `{ type: 'null' }` branch, as emitted by z.toJSONSchema() for `.nullable()`. */
+const isNullBranch = (branch: unknown): boolean =>
+  typeof branch === 'object' &&
+  branch !== null &&
+  !Array.isArray(branch) &&
+  (branch as Record<string, unknown>).type === 'null' &&
+  Object.keys(branch as Record<string, unknown>).length === 1;
+
+/**
+ * Whether a branch has to stay behind a combiner instead of being merged into
+ * its parent. OAS 3.0 ignores keywords sibling to `$ref`, so a merged
+ * `{ $ref, nullable: true }` would silently lose the nullability. A branch still
+ * carrying `COMPONENT_ID_MARKER` becomes a `$ref` later in `hoistMarkedSchemas`,
+ * and merging it would additionally hoist the parent's `nullable` and
+ * `description` into the shared component.
+ */
+const mustStayBoxed = (branch: Record<string, unknown>): boolean =>
+  '$ref' in branch || COMPONENT_ID_MARKER in branch;
+
+/**
+ * Collapse a `{ type: 'null' }` branch out of `anyOf`/`oneOf`, reporting whether
+ * one was found so the caller can set `nullable: true` on the result.
+ *
+ * Runs before the recursive descent: the descent rewrites a standalone
+ * `{ type: 'null' }` into `{ nullable: true }`, which no longer matches
+ * `isNullBranch`.
+ */
+function collapseNullBranches(node: Record<string, unknown>): {
+  node: Record<string, unknown>;
+  nullable: boolean;
+} {
+  let result = node;
+  let nullable = false;
+
+  for (const combiner of ['anyOf', 'oneOf'] as const) {
+    const branches = result[combiner];
+    if (!Array.isArray(branches)) continue;
+
+    const nullIdx = branches.findIndex(isNullBranch);
+    if (nullIdx === -1) continue;
+
+    const remaining = branches.filter((_: unknown, i: number) => i !== nullIdx);
+    nullable = true;
+
+    const [sole] = remaining;
+    const soleIsMergeable =
+      remaining.length === 1 &&
+      typeof sole === 'object' &&
+      sole !== null &&
+      !Array.isArray(sole) &&
+      !mustStayBoxed(sole as Record<string, unknown>);
+
+    if (soleIsMergeable) {
+      const { [combiner]: _combiner, ...rest } = result;
+      result = { ...rest, ...(sole as Record<string, unknown>) };
+    } else if (remaining.length === 1) {
+      const { [combiner]: _combiner, ...rest } = result;
+      result = { ...rest, allOf: remaining };
+    } else {
+      result = { ...result, [combiner]: remaining };
+    }
+  }
+
+  return { node: result, nullable };
+}
+
 /**
  * Recursively transform a JSON Schema object (OAS 3.1 / JSON Schema draft 2020-12)
  * into an OpenAPI 3.0-compatible Schema Object.
@@ -716,11 +782,13 @@ function mergeInlineOasExtensions(node: unknown): unknown {
 function jsonSchemaToOpenApi30(node: Record<string, unknown>): Record<string, unknown> {
   if (typeof node !== 'object' || node === null) return node;
 
-  let result: Record<string, unknown> = {};
+  const { node: collapsed, nullable } = collapseNullBranches(node);
 
-  const hasPropertyNames = 'propertyNames' in node;
+  const result: Record<string, unknown> = {};
 
-  for (const [key, value] of Object.entries(node)) {
+  const hasPropertyNames = 'propertyNames' in collapsed;
+
+  for (const [key, value] of Object.entries(collapsed)) {
     // Strip `propertyNames` (not supported in OAS 3.0)
     if (key === 'propertyNames') continue;
     // Strip companion `required` emitted by z.toJSONSchema() for z.record(z.enum([...]), ...)
@@ -746,43 +814,13 @@ function jsonSchemaToOpenApi30(node: Record<string, unknown>): Record<string, un
     }
   }
 
-  // Handle `anyOf`/`oneOf` containing `{ type: 'null' }` branches:
-  // Pull out the null branch and set `nullable: true` on the remaining schema.
-  for (const combiner of ['anyOf', 'oneOf'] as const) {
-    const branches = result[combiner];
-    if (!Array.isArray(branches)) continue;
-
-    const nullIdx = branches.findIndex(
-      (b: unknown) =>
-        typeof b === 'object' &&
-        b !== null &&
-        (b as Record<string, unknown>).type === 'null' &&
-        Object.keys(b as Record<string, unknown>).length === 1
-    );
-
-    if (nullIdx === -1) continue;
-
-    // Remove the null branch
-    const remaining = branches.filter((_: unknown, i: number) => i !== nullIdx);
-
-    if (remaining.length === 1) {
-      // Single remaining branch: merge it into the current level with nullable
-      const [sole] = remaining;
-      if (typeof sole === 'object' && sole !== null) {
-        // Remove the combiner key, spread the sole schema, add nullable
-        delete result[combiner];
-        result = { ...result, ...(sole as Record<string, unknown>), nullable: true };
-      }
-    } else {
-      // Multiple remaining branches: keep the combiner, add nullable
-      result[combiner] = remaining;
-      result.nullable = true;
-    }
-  }
-
   // Handle top-level `type: 'null'` (standalone null schema)
   if (result.type === 'null') {
     delete result.type;
+    result.nullable = true;
+  }
+
+  if (nullable) {
     result.nullable = true;
   }
 


### PR DESCRIPTION
## Summary

Every `z.…nullable()` on a route schema currently reaches the published OAS bundle as a half-converted union:

```yaml
createdBy:
  anyOf:
    - type: string
    - nullable: true
  description: User who created the rule.
```

The second branch has no type and constrains nothing, so `oapi-codegen` treats it as an untyped union member and renders a `json.RawMessage` wrapper instead of `*string`. There are 43 affected occurrences on `main` across 21 operations; [#279519](https://github.com/elastic/kibana/pull/279519) would add 37 more.

The converter in `kbn-router-to-openapispec` already had logic to collapse null branches, but it ran after the recursive descent. The descent rewrote the child `{ type: 'null' }` to `{ nullable: true }` first, so the scan that followed always came up empty. Zod was emitting the right thing; only the downconversion was broken.

In this PR we move `collapseNullBranches` to run before the descent. A sole remaining branch merges into its parent when it's a plain schema; when it carries a `$ref` or `x-kbn-oas-component-id` (which becomes a `$ref` later in `hoistMarkedSchemas`), it's boxed in `allOf: [{ $ref }]` instead. That's the canonical nullable-ref form the `@kbn/config-schema` path already produces in 67 places. We also widen the Redocly `no-empty-nullable-enum` guard to catch the bare `{ nullable: true }` spelling the Zod converter was leaking, not just the `{ enum: [], nullable: true }` spelling from config-schema.

After this, `createdBy` becomes `{ type: string, nullable: true, description: … }`. Merging this before [#279519](https://github.com/elastic/kibana/pull/279519) means the Alerting v2 surface publishes the canonical shape from day one rather than shipping `anyOf` wrappers that would need correcting after the fact.

Found while reviewing [#279519](https://github.com/elastic/kibana/pull/279519) ([comment](https://github.com/elastic/kibana/pull/279519#discussion_r3618605876)).

## Changes

- Move null-branch collapse in `kbn-router-to-openapispec/src/oas_converter/zod/lib.ts` to run before the recursive descent
- Box `$ref` and `COMPONENT_ID_MARKER` branches in `allOf` rather than merging, to avoid OAS 3.0 silently dropping keywords sibling to `$ref`
- Widen `isNullablePlaceholder` in the `kbn-validate-oas` Redocly linter to catch bare `{ nullable: true }` in addition to `{ enum: [], nullable: true }`
- Add 4 scoped allowlist entries in `kbn-api-contracts` for the gating operations

## Breaking changes

The contract checker flags 21 operations on stack and 20 on serverless. All are OAS representation fixes; the same values are accepted and returned at runtime.

**4 gating operations (stable/tech_preview)**

| Operation | oasdiff id | Owner |
|---|---|---|
| `POST /api/fleet/epm/packages/_bulk` | `response-property-became-nullable` | `@elastic/fleet` |
| `POST /api/security/entity_store/entities/{entityType}` | `request-body-any-of-removed` | `@elastic/security-entity-analytics` |
| `PUT /api/security/entity_store/entities/{entityType}` | `request-body-any-of-removed` | `@elastic/security-entity-analytics` |
| `PUT /api/security/entity_store/entities/bulk` | `request-property-any-of-removed` | `@elastic/security-entity-analytics` |

Each allowlist entry is scoped by `oasdiffId` so every other contract check on those endpoints stays active. Sign-offs from `@elastic/fleet` and `@elastic/security-entity-analytics` are pending. This PR is ready to review but should stay in draft until those are confirmed.

The other 17 flagged operations are `x-state: Experimental` and don't gate.

<details>
<summary>How to test this</summary>

1. Run the converter unit tests:

```bash
node scripts/jest src/platform/packages/shared/kbn-router-to-openapispec
```

284 tests should pass. The 8 new `.nullable()` cases cover: scalar collapse, `.nullish()`, multi-branch union, nullable enum, nested nullable object, nullable named component, nullable recursive `$ref`, and a guard that no `{"nullable":true}` branch survives in the output.

2. Run the linter tests:

```bash
node scripts/jest src/platform/packages/private/kbn-validate-oas
```

52 tests should pass, including the new case for the bare `{ nullable: true }` spelling.

3. Run the contract checker tests:

```bash
node scripts/jest packages/kbn-api-contracts
```

167 tests should pass.

4. Type-check the converter:

```bash
node scripts/type_check --project src/platform/packages/shared/kbn-router-to-openapispec/tsconfig.json
```

Should be clean.

5. To inspect the bundle change: `oas_docs/output/*.yaml` isn't committed here; CI regenerates it. To preview locally, run `node scripts/capture_oas_snapshot` and diff against `main`. Every `anyOf: [T, { nullable: true }]` pattern from zod-backed routes should become `{ type: ..., nullable: true }`.

</details>

## Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.

## Identify risks

This is scoped to OAS output only; no runtime behavior changes.

| Risk | Severity | Likelihood | Mitigation |
|---|---|---|---|
| Bundle-wide OAS shape change affects pattern-matching consumers | Low | Low | Representation fix only; accepted/returned values unchanged. Gating operations are scoped by `oasdiffId` rather than blanket-suppressed. |
| `allOf: [{ $ref }]` + `nullable: true` is new for some consumers | None | Not observed | This form already appears 67 times from the config-schema path. Covered by two dedicated tests. |
| Sign-offs from Fleet and Security Entity Analytics pending | Low | Pending | Allowlist entries are scoped to the four specific operations and oasdiff ids. No other contract checks on those endpoints are affected. |
